### PR TITLE
Decreased GPU Memory size

### DIFF
--- a/rpi-seedsigner/board/raspberrypi/config_seedsigner.txt
+++ b/rpi-seedsigner/board/raspberrypi/config_seedsigner.txt
@@ -6,9 +6,9 @@ kernel=zImage
 
 # How much memory in MB to assign to the GPU on Pi models having
 # 256, 512 or 1024 MB total memory
-gpu_mem_256=100
-gpu_mem_512=100
-gpu_mem_1024=100
+gpu_mem_256=25
+gpu_mem_512=25
+gpu_mem_1024=25
 
 # Enable Camera module
 start_x=1


### PR DESCRIPTION
That mount of memory size isn't really necessary to get camera working.
So having less GPU size which is taken from RAM we are going to have the rest space free to use in other tasks.