### PR TITLE
update apt install to include libssl-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,5 +80,5 @@ Because we are cross-compiling with Buildroot, we need certains tools for that t
 Usually, Debian based OS have all dependences already installed by default. But using this command you can install the main packages in case needed:
 
 ```bash
-sudo apt update && sudo apt install make binutils build-essential gcc g++ patch gzip bzip2 perl tar cpio unzip rsync file bc
+sudo apt update && sudo apt install make binutils build-essential gcc g++ patch gzip bzip2 perl tar cpio unzip rsync file bc libssl-dev
 ```


### PR DESCRIPTION
Adding libssl-dev to the apt install list. This dependency is required for the dev build only