### PR TITLE
Remove gzip of img file and remove the move command of the config folder

### DIFF
--- a/opt/build.sh
+++ b/opt/build.sh
@@ -90,8 +90,6 @@ build_image() {
   
   if [ -f "${build_dir}/images/seedsigner_os.img" ] && [ -d "${image_dir}" ]; then
     mv -f "${build_dir}/images/seedsigner_os.img" "${image_dir}/seedsigner_os.${seedsigner_app_repo_branch}.${config_name}.img"
-    gzip -f "${image_dir}/seedsigner_os.${seedsigner_app_repo_branch}.${config_name}.img"
-    mv -f "${build_dir}/images" "${image_dir}/seedsigner_os.${seedsigner_app_repo_branch}.${config_name}"
   fi
   
   cd - # return to previous working directory


### PR DESCRIPTION
No need to gzip the image, just makes it harder to use on different platforms (macOS, Windows, Linux)