### PR TITLE
libncurses-dev added in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ lsb-release \
 git \
 wget \
 make \
-binutils \gcc \
+binutils \
+gcc \
 g++ \
 patch \
 gzip \
@@ -22,7 +23,8 @@ file \
 bc \
 libssl-dev \
 vim \
-build-essential 
+build-essential \ 
+libncurses-dev
 
 # Locale
 RUN locale-gen en_US.UTF-8  


### PR DESCRIPTION
libncurses-dev is required to use `make menuconfig` and others menus.