### PR TITLE
Update embit to version 0.7.0

### DIFF
--- a/opt/external-packages/python-embit/python-embit.hash
+++ b/opt/external-packages/python-embit/python-embit.hash
@@ -1,3 +1,3 @@
 # md5, sha256 from https://pypi.org/project/embit/#copy-hash-modal-0adf5c0d-26d5-4b77-b9d4-2ebd488fb1c9
-md5  f44cfb6927dcb729ce17a71a6f6dbcc5  embit-0.6.1.tar.gz
-sha256	16a84c6668dc9ffc907594457a46f7142cee379646bc009a5a9b77b0d2cb4e12  embit-0.6.1.tar.gz
+md5  c43ce954576a2d08896aeeade89fc75d  embit-0.7.0.tar.gz
+sha256	3dbd42582b5c3e40623e7b2af02956ba6019f6e1ca1c3363f27aa9f9bca03366  embit-0.7.0.tar.gz

--- a/opt/external-packages/python-embit/python-embit.mk
+++ b/opt/external-packages/python-embit/python-embit.mk
@@ -4,9 +4,9 @@
 #
 ################################################################################
 
-PYTHON_EMBIT_VERSION = 0.6.1
+PYTHON_EMBIT_VERSION = 0.7.0
 PYTHON_EMBIT_SOURCE = embit-$(PYTHON_EMBIT_VERSION).tar.gz
-PYTHON_EMBIT_SITE = https://files.pythonhosted.org/packages/9a/74/e5e213b5c6471eb56d773eb936ba14c3a4e04ab6c6069a56c0d9a0278a39
+PYTHON_EMBIT_SITE = https://files.pythonhosted.org/packages/39/51/9f606c964a45e74cc9df259c5df5e69586c491178bf2972a59b40a889be0
 PYTHON_EMBIT_LICENSE = MIT
 PYTHON_EMBIT_SETUP_TYPE = setuptools
 


### PR DESCRIPTION
Emit version 0.7.0 is required for seedsigner branch 0.5.2 or higher using bip-85