### PR TITLE
Bump default branch to version to 0.6.0

### DIFF
--- a/opt/build.sh
+++ b/opt/build.sh
@@ -4,7 +4,7 @@
 cur_dir_name=${PWD##*/}
 cur_dir=$(pwd)
 seedsigner_app_repo="https://github.com/SeedSigner/seedsigner.git"
-seedsigner_app_repo_branch="0.5.2"
+seedsigner_app_repo_branch="0.6.0"
 
 help()
 {


### PR DESCRIPTION
A decision was made to skip 0.5.2 and go to 0.6.0 instead. The move from Raspberry Pi OS to SeedSigner OS is a big part of this justification. The change to SeedSigner OS justifies not a minor release version bump as originally planned.

Branch 0.6.0 needs to be created in the app repo AND PR https://github.com/SeedSigner/seedsigner/pull/317 in the app repo should be merged BEFORE merging this PR.