### PR TITLE
Stop build when git clone fails

### DIFF
--- a/opt/build.sh
+++ b/opt/build.sh
@@ -40,7 +40,7 @@ download_app_repo() {
   
   # Download SeedSigner from GitHub and put into rootfs
   echo "cloning repo ${seedsigner_app_repo} with branch ${seedsigner_app_repo_branch}"
-  git clone --depth 1 -b "${seedsigner_app_repo_branch}" "${seedsigner_app_repo}" "${rootfs_overlay}/opt/"
+  git clone --depth 1 -b "${seedsigner_app_repo_branch}" "${seedsigner_app_repo}" "${rootfs_overlay}/opt/" || exit
         
   # Delete unnecessary files to save space
   rm -rf ${rootfs_overlay}/opt/.git


### PR DESCRIPTION
Currently, in the build.sh script the git clone step can fail (invalid branch as an example) and the build will continue. Instead it would be better if the build.sh script exited on failure to clone the repo. This PR adds an exit 1 on the git clone step.