### PR TITLE
rm requirements-raspi.txt

### DIFF
--- a/opt/build.sh
+++ b/opt/build.sh
@@ -57,6 +57,7 @@ download_app_repo() {
   rm -rf ${rootfs_overlay}/opt/.git
   rm -rf ${rootfs_overlay}/opt/.gitignore
   rm -rf ${rootfs_overlay}/opt/requirements.txt
+  rm -rf ${rootfs_overlay}/opt/requirements-raspi.txt
   rm -rf ${rootfs_overlay}/opt/docs
   rm -rf ${rootfs_overlay}/opt/README.md
   rm -rf ${rootfs_overlay}/opt/LICENSE.md


### PR DESCRIPTION
resolves #53

Since seedsigner's pr-339 (flow tests), an extra requirements-raspi.txt file is left in /opt/

Merging this will alter the final image hash, so consider leaving this as a "to-do" until just before release if others are still attempting reproducible-builds based on Nick's pr #51 gist.