### PR TITLE
Adding codespaces functionality to seed signer os

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,15 +1,6 @@
-
 {
-    "workspaceFolder": "/",
 
-    "remoteEnv": {
-      "CODESPACE_VSCODE_FOLDER" : "/"
-    },
-    
-    
     "build": { "dockerfile": "../Dockerfile" },
-
-    "postCreateCommand": "git submodule update --init"
-
     
   }
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 	},
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
-	}
+	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
@@ -19,7 +19,7 @@
 	// "forwardPorts": [],
 
 	// Uncomment the next line to run commands after the container is created.
-	// "postCreateCommand": "cat /etc/os-release",
+	"postCreateCommand": "git submodule update --init",
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,18 +12,7 @@
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
 	},
 
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
 	// Uncomment the next line to run commands after the container is created.
-	"postCreateCommand": "git submodule update --init",
+	"postCreateCommand": "git submodule update --init"
 
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "devcontainer"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,29 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
 {
+	"name": "Existing Dockerfile",
+	"build": {
+		// Sets the run context to one level up instead of the .devcontainer folder.
+		"context": "..",
+		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+		"dockerfile": "../Dockerfile"
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+	}
 
-    "build": { "dockerfile": "../Dockerfile" },
-    
-  }
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
 
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,10 @@
 
 {
-    "workspaceFolder": "/"
+    "workspaceFolder": "/",
     
     "build": { "dockerfile": "../Dockerfile" },
 
-    "postCreateCommand": "git submodule update --init",
+    "postCreateCommand": "git submodule update --init"
 
     
   }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+
+{
+    "build": { "dockerfile": "../Dockerfile" },
+
+    "postCreateCommand": "git submodule update --init",
+
+    "workspaceFolder": "/"
+  }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,10 @@
 
 {
+    "workspaceFolder": "/"
+    
     "build": { "dockerfile": "../Dockerfile" },
 
     "postCreateCommand": "git submodule update --init",
 
-    "workspaceFolder": "/"
+    
   }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,11 @@
 
 {
     "workspaceFolder": "/",
+
+    "remoteEnv": {
+      "CODESPACE_VSCODE_FOLDER" : "/"
+    },
+    
     
     "build": { "dockerfile": "../Dockerfile" },
 


### PR DESCRIPTION
This dev container file sets up the dev container environment for docker and pulls the submodule code (buildroot), as a post create command, into the codespaces cloud ide. I verified all 4 pi board hashes.