### PR TITLE
Removed apt install package versions because it was causing dependenc…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,32 +2,34 @@ FROM debian:11
 
 # buildroot dependencies
 RUN apt-get -qq update
-RUN apt-get -qq -y install \
-locales=2.31-13+deb11u6 \
-lsb-release=11.1.0 \
-git=1:2.30.2-1+deb11u2 \
-wget=1.21-1+deb11u1 \
-make=4.3-4.1 \
-binutils=2.35.2-2 \
-gcc=4:10.2.1-1 \
-g++=4:10.2.1-1 \
-patch=2.7.6-7 \
-gzip=1.10-4+deb11u1 \
-bzip2=1.0.8-4 \
-perl=5.32.1-4+deb11u2 \
-tar=1.34+dfsg-1 \
-cpio=2.13+dfsg-4 \
-unzip=6.0-26+deb11u1 \
-rsync=3.2.3-4+deb11u1 \
-file=1:5.39-3 \
-bc=1.07.1-2+b2 \
-libssl-dev=1.1.1n-0+deb11u5 \
-vim=2:8.2.2434-3+deb11u1 \
-build-essential=12.9 \ 
-libncurses-dev=6.2+20201114-2+deb11u1 \
-mtools=4.0.26-1 \
-fdisk=2.36.1-8+deb11u1 \
-dosfstools=4.2-1
+RUN apt-get -y install \
+locales \
+lsb-release \
+git \
+wget \
+make \
+binutils \
+gcc \
+g++ \
+patch \
+gzip \
+bzip2 \
+perl \
+tar \
+cpio \
+unzip \
+rsync \
+libmagic1 \
+libmagic-mgc \
+file \
+bc \
+libssl-dev \
+vim \
+build-essential \
+libncurses-dev \
+mtools \
+fdisk \
+dosfstools
 
 # Locale
 RUN locale-gen en_US.UTF-8  

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,6 @@ tar \
 cpio \
 unzip \
 rsync \
-libmagic1 \
-libmagic-mgc \
 file \
 bc \
 libssl-dev \


### PR DESCRIPTION
Removing apt install package versions because it is causing dependencies errors when a stable debian 11 package was updated the dependencies is not specified in the install command. I'm also worried these older versions will become unsupported and won't be available for download.

As of 9/4 this is the error you will see when building the docker image from the Dockerfile:

```
$ DOCKER_DEFAULT_PLATFORM=linux/amd64 SS_ARGS="--no-op" docker compose up --force-recreate --build --detach
[+] Building 8.5s (6/12)                                                                                                                                                                 docker:desktop-linux
 => [build-images internal] load build definition from Dockerfile                                                                                                                                        0.0s
 => => transferring dockerfile: 1.03kB                                                                                                                                                                   0.0s
 => [build-images internal] load .dockerignore                                                                                                                                                           0.0s
 => => transferring context: 2B                                                                                                                                                                          0.0s
 => [build-images internal] load metadata for docker.io/library/debian:11                                                                                                                                0.9s
 => [build-images 1/9] FROM docker.io/library/debian:11@sha256:1beb7cf458bdfe71b5220cb2069eb45e3fc7eb77a1ccfb169eaebf5f6c4809ab                                                                          3.4s
 => => resolve docker.io/library/debian:11@sha256:1beb7cf458bdfe71b5220cb2069eb45e3fc7eb77a1ccfb169eaebf5f6c4809ab                                                                                       0.0s
 => => sha256:1beb7cf458bdfe71b5220cb2069eb45e3fc7eb77a1ccfb169eaebf5f6c4809ab 1.85kB / 1.85kB                                                                                                           0.0s
 => => sha256:7ac88cb3b95d347e89126a46696374fab97153b63d25995a5c6e75b5e98a0c79 529B / 529B                                                                                                               0.0s
 => => sha256:07585eb557378946b168a6d3e6eba76f310d0f0fa9872d010844a2d7ebe9c1eb 1.46kB / 1.46kB                                                                                                           0.0s
 => => sha256:6a70103cc499a199e10e379794c60aa524d9598587cc2bdfe2995642c2da8df7 55.06MB / 55.06MB                                                                                                         1.9s
 => => extracting sha256:6a70103cc499a199e10e379794c60aa524d9598587cc2bdfe2995642c2da8df7                                                                                                                1.4s
 => [build-images 2/9] RUN apt-get -qq update                                                                                                                                                            3.3s
 => ERROR [build-images 3/9] RUN apt-get -qq -y install locales=2.31-13+deb11u6 lsb-release=11.1.0 git=1:2.30.2-1+deb11u2 wget=1.21-1+deb11u1 make=4.3-4.1 binutils=2.35.2-2 gcc=4:10.2.1-1 g++=4:10.2.  0.8s
------
 > [build-images 3/9] RUN apt-get -qq -y install locales=2.31-13+deb11u6 lsb-release=11.1.0 git=1:2.30.2-1+deb11u2 wget=1.21-1+deb11u1 make=4.3-4.1 binutils=2.35.2-2 gcc=4:10.2.1-1 g++=4:10.2.1-1 patch=2.7.6-7 gzip=1.10-4+deb11u1 bzip2=1.0.8-4 perl=5.32.1-4+deb11u2 tar=1.34+dfsg-1 cpio=2.13+dfsg-4 unzip=6.0-26+deb11u1 rsync=3.2.3-4+deb11u1 file=1:5.39-3 bc=1.07.1-2+b2 libssl-dev=1.1.1n-0+deb11u5 vim=2:8.2.2434-3+deb11u1 build-essential=12.9 libncurses-dev=6.2+20201114-2+deb11u1 mtools=4.0.26-1 fdisk=2.36.1-8+deb11u1 dosfstools=4.2-1:
0.814 E: Unable to correct problems, you have held broken packages.
------
failed to solve: process "/bin/sh -c apt-get -qq -y install locales=2.31-13+deb11u6 lsb-release=11.1.0 git=1:2.30.2-1+deb11u2 wget=1.21-1+deb11u1 make=4.3-4.1 binutils=2.35.2-2 gcc=4:10.2.1-1 g++=4:10.2.1-1 patch=2.7.6-7 gzip=1.10-4+deb11u1 bzip2=1.0.8-4 perl=5.32.1-4+deb11u2 tar=1.34+dfsg-1 cpio=2.13+dfsg-4 unzip=6.0-26+deb11u1 rsync=3.2.3-4+deb11u1 file=1:5.39-3 bc=1.07.1-2+b2 libssl-dev=1.1.1n-0+deb11u5 vim=2:8.2.2434-3+deb11u1 build-essential=12.9 libncurses-dev=6.2+20201114-2+deb11u1 mtools=4.0.26-1 fdisk=2.36.1-8+deb11u1 dosfstools=4.2-1" did not complete successfully: exit code: 100
```

If you remove the quiet flags from `apt-get install` you'll see a more specific error text:

```
0.700 Some packages could not be installed. This may mean that you have
0.700 requested an impossible situation or if you are using the unstable
0.700 distribution that some required packages have not yet been created
0.700 or been moved out of Incoming.
0.700 The following information may help to resolve the situation:
0.700
0.700 The following packages have unmet dependencies:
0.737  file : Depends: libmagic1 (= 1:5.39-3) but 1:5.39-3+deb11u1 is to be installed
0.747 E: Unable to correct problems, you have held broken packages.
```

The [file](https://packages.debian.org/bullseye/file) package has a dependency on `libmagic1`. You can see that [libmagic1](https://packages.debian.org/bullseye/libmagic1) was updated here: https://tracker.debian.org/pkg/file

From what I know (and I'm happy to be corrected). I think the best option is to remove these specific versions. The packages apt installs in the Dockerfile are not directly used to build SeedSigner OS. They are only needed because Buildroot depends on them to setup the host env to actually build the embedded linux OS. My worry with identifying more specific versions of dependencies is that some of these versions might eventually not be available for download.

The alternative approach is documented in PR #62 