### PR TITLE
Stop build.sh on any error so that it exits with exit_code != 0 on error

### DIFF
--- a/opt/build.sh
+++ b/opt/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o errexit -o pipefail
+
 # global variables
 cur_dir_name=${PWD##*/}
 cur_dir=$(pwd)


### PR DESCRIPTION
bash has the default behaviour to continue on any error. This typically leads to the situation of exit_code == 0 even when the make calls failed and did't produce a image as can be found here https://github.com/SeedSigner/seedsigner/actions/runs/12921826216 ... the `build step` (which executes the build.sh) isn't marked as red due to exit_code == 0 and only a later steps fails due to not created image.

This PR updates the build.sh to exit on any command call with exit_code != 0 immediately revealing that something went wrong. It also enables that sub-commands which are piped together to propagate their error to an overall error. With that set errors can also be individually ignored when required by e.g. `$cmd_with_error || true`.

