### PR TITLE
Remove obsolete docker compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.1'
 services:
   build-images:
     build:


### PR DESCRIPTION
Version top-level element is now obsolete https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-optional