### PR TITLE
Increase DOS partition size to 40MB to accommodate I10n changes

### DIFF
--- a/opt/pi0/board/post-image-seedsigner.sh
+++ b/opt/pi0/board/post-image-seedsigner.sh
@@ -17,7 +17,7 @@ mkdir -p ${BUILD_DIR}/custom_image
 cd ${BUILD_DIR}/custom_image
 
 # Create disk image.
-dd if=/dev/zero of=disk.img bs=1M count=25  # block size (1MB) * count = size allocated for image
+dd if=/dev/zero of=disk.img bs=1M count=40  # block size (1MB) * count = size allocated for image
 
 ### needed: apt install fdisk
 /sbin/sfdisk disk.img <<EOF

--- a/opt/pi02w/board/post-image-seedsigner.sh
+++ b/opt/pi02w/board/post-image-seedsigner.sh
@@ -17,7 +17,7 @@ mkdir -p ${BUILD_DIR}/custom_image
 cd ${BUILD_DIR}/custom_image
 
 # Create disk image.
-dd if=/dev/zero of=disk.img bs=1M count=26 #26 MB
+dd if=/dev/zero of=disk.img bs=1M count=40 # block size (1MB) * count = size allocated for image
 
 ### needed: apt install fdisk
 /sbin/sfdisk disk.img <<EOF

--- a/opt/pi2/board/post-image-seedsigner.sh
+++ b/opt/pi2/board/post-image-seedsigner.sh
@@ -17,7 +17,7 @@ mkdir -p ${BUILD_DIR}/custom_image
 cd ${BUILD_DIR}/custom_image
 
 # Create disk image.
-dd if=/dev/zero of=disk.img bs=1M count=26 #26 MB
+dd if=/dev/zero of=disk.img bs=1M count=40 # block size (1MB) * count = size allocated for image
 
 ### needed: apt install fdisk
 /sbin/sfdisk disk.img <<EOF

--- a/opt/pi4/board/post-image-seedsigner.sh
+++ b/opt/pi4/board/post-image-seedsigner.sh
@@ -17,7 +17,7 @@ mkdir -p ${BUILD_DIR}/custom_image
 cd ${BUILD_DIR}/custom_image
 
 # Create disk image.
-dd if=/dev/zero of=disk.img bs=1M count=26 #26 MB
+dd if=/dev/zero of=disk.img bs=1M count=40 # block size (1MB) * count = size allocated for image
 
 ### needed: apt install fdisk
 /sbin/sfdisk disk.img <<EOF


### PR DESCRIPTION
PR [seedsigner#686](https://github.com/SeedSigner/seedsigner/pull/686) adds files and structure for additional languages. This required adding additional font files that consumes more space on disk. This bump to 40MB leaves a little extra space for larger messages.mo as additional translations get added.