### PR TITLE
Add seedsigner-translation compile as build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11
+FROM debian:12
 
 # buildroot dependencies
 RUN apt-get -qq update
@@ -28,7 +28,10 @@ libncurses-dev \
 mtools \
 fdisk \
 dosfstools \
-ccache
+ccache \
+python3 \
+python3-pip \
+python3-virtualenv
 
 # Locale
 RUN locale-gen en_US.UTF-8  

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -55,6 +55,18 @@ download_app_repo() {
     git clone --recurse-submodules --depth 1 -b "${seedsigner_app_repo_branch}" "${seedsigner_app_repo}" "${rootfs_overlay}/opt/" || exit
   fi
 
+  # create virtual env to compile translation files
+  virtualenv .translation-venv
+  source .translation-venv/bin/activate
+  cd ${rootfs_overlay}/opt
+  pip install babel || exit
+  pip install -e . || exit
+  # remove any existing binary mo files if they exist
+  rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/l10n/**/**/*.mo
+  python3 setup.py compile_catalog || exit
+  cd -
+  deactivate
+
   # Delete unnecessary files to save space
   # folders
   rm -rf ${rootfs_overlay}/opt/.github
@@ -80,7 +92,7 @@ download_app_repo() {
 
   rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/LICENSE
   rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/README.md
-  rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/l10n/**/*.po
+  rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/l10n/**/**/*.po
 }
 
 build_image() {
@@ -113,6 +125,8 @@ build_image() {
     download_app_repo
   fi
   
+  exit
+
   # Setup external tree
   #make BR2_EXTERNAL="../${config_dir}/" O="${build_dir}" -C ./buildroot/ #2> /dev/null > /dev/null
 

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -124,8 +124,6 @@ build_image() {
   if [ "${3}" != "skip-repo" ]; then
     download_app_repo
   fi
-  
-  exit
 
   # Setup external tree
   #make BR2_EXTERNAL="../${config_dir}/" O="${build_dir}" -C ./buildroot/ #2> /dev/null > /dev/null


### PR DESCRIPTION
Current state the seedsigner-translation repo needs to include the messages.mo (binary) files in the repo. This is hard to audit and review. Moving the compile step of creating the binary messages.mo files to build.sh makes it so this step is part of the reproducible build and removes a step that requires trust.

Additional Notes:
- Docker environment updated to Debian 12 (from 11) to get access to the default python version 3.11 (instead of 3.9).
- additional docker environment packages added to create a virtualenv in python and enable the ability to run the `python3 setup.py compile_catalog` command (generating messages.mo files for each language)
- Clean up command for messages.po corrected (was not previously actually finding and deleting the text messages.po files).