### PR TITLE
Increase disk image size to 50 MB from 45 MB to solve CI/CD issues

### DIFF
--- a/opt/pi0/board/post-image-seedsigner.sh
+++ b/opt/pi0/board/post-image-seedsigner.sh
@@ -17,7 +17,7 @@ mkdir -p ${BUILD_DIR}/custom_image
 cd ${BUILD_DIR}/custom_image
 
 # Create disk image.
-dd if=/dev/zero of=disk.img bs=1M count=45  # block size (1MB) * count = size allocated for image
+dd if=/dev/zero of=disk.img bs=1M count=50  # block size (1MB) * count = size allocated for image
 
 ### needed: apt install fdisk
 /sbin/sfdisk disk.img <<EOF

--- a/opt/pi02w/board/post-image-seedsigner.sh
+++ b/opt/pi02w/board/post-image-seedsigner.sh
@@ -17,7 +17,7 @@ mkdir -p ${BUILD_DIR}/custom_image
 cd ${BUILD_DIR}/custom_image
 
 # Create disk image.
-dd if=/dev/zero of=disk.img bs=1M count=45 # block size (1MB) * count = size allocated for image
+dd if=/dev/zero of=disk.img bs=1M count=50 # block size (1MB) * count = size allocated for image
 
 ### needed: apt install fdisk
 /sbin/sfdisk disk.img <<EOF

--- a/opt/pi2/board/post-image-seedsigner.sh
+++ b/opt/pi2/board/post-image-seedsigner.sh
@@ -17,7 +17,7 @@ mkdir -p ${BUILD_DIR}/custom_image
 cd ${BUILD_DIR}/custom_image
 
 # Create disk image.
-dd if=/dev/zero of=disk.img bs=1M count=45 # block size (1MB) * count = size allocated for image
+dd if=/dev/zero of=disk.img bs=1M count=50 # block size (1MB) * count = size allocated for image
 
 ### needed: apt install fdisk
 /sbin/sfdisk disk.img <<EOF

--- a/opt/pi4/board/post-image-seedsigner.sh
+++ b/opt/pi4/board/post-image-seedsigner.sh
@@ -17,7 +17,7 @@ mkdir -p ${BUILD_DIR}/custom_image
 cd ${BUILD_DIR}/custom_image
 
 # Create disk image.
-dd if=/dev/zero of=disk.img bs=1M count=45 # block size (1MB) * count = size allocated for image
+dd if=/dev/zero of=disk.img bs=1M count=50 # block size (1MB) * count = size allocated for image
 
 ### needed: apt install fdisk
 /sbin/sfdisk disk.img <<EOF


### PR DESCRIPTION
Since early September the CI/CD build workflow in the seedsigner app repo started failed because the disk was running out of space. See https://github.com/SeedSigner/seedsigner/actions/runs/17421458825 as an example.

This PR bumps the size size from 45MB to 50BM. Once translation font files are optimized the disk image size can be lowered. Until then I wanted CI/CD build workflow to continue working.