### PR TITLE
[Feature] Support `Version` info screen; writes `version.json` during build

### DIFF
--- a/opt/build.sh
+++ b/opt/build.sh
@@ -53,7 +53,10 @@ download_app_repo() {
     cd -
   else
     echo "cloning repo ${seedsigner_app_repo} with branch ${seedsigner_app_repo_branch}"
-    git clone --recurse-submodules -b "${seedsigner_app_repo_branch}" "${seedsigner_app_repo}" "${rootfs_overlay}/opt/" || exit
+    git clone --recurse-submodules "${seedsigner_app_repo}" "${rootfs_overlay}/opt/" || exit
+    cd ${rootfs_overlay}/opt/
+    git checkout "${seedsigner_app_repo_branch}" || exit
+    cd -
   fi
 
   # create virtual env to compile translation files

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -52,12 +52,12 @@ download_app_repo() {
     git reset --hard "${seedsigner_app_repo_commit_id}"
     cd -
     # Provide env var to the version.py script used below
-    export SEEDSIGNER_VERSION_NAME="${seedsigner_app_repo_commit_id}"
+    export SEEDSIGNER_VERSION_NAME=${seedsigner_app_repo_commit_id}
   else
     echo "cloning repo ${seedsigner_app_repo} with branch ${seedsigner_app_repo_branch}"
     git clone --recurse-submodules --depth 1 -b "${seedsigner_app_repo_branch}" "${seedsigner_app_repo}" "${rootfs_overlay}/opt/" || exit
     # Provide env var to the version.py script used below
-    export SEEDSIGNER_VERSION_NAME="${seedsigner_app_repo_branch}"
+    export SEEDSIGNER_VERSION_NAME=${seedsigner_app_repo_branch}
   fi
 
   # create virtual env to compile translation files
@@ -75,6 +75,7 @@ download_app_repo() {
 
   # Write the src/seedsigner/version.json file.
   cd ${rootfs_overlay}/opt/src
+  echo $SEEDSIGNER_VERSION_NAME
   python3 seedsigner/helpers/version.py || exit
   cat seedsigner/version.json
 

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -66,9 +66,10 @@ download_app_repo() {
   rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/l10n/**/**/*.mo
   python3 setup.py compile_catalog || exit
 
-  # Set the buildroot SOURCE_DATE_EPOCH to mark all files with last commit date for reproducible builds
-  export SOURCE_DATE_EPOCH=$(git log -1 --format=%at 2> /dev/null)
-  echo "Setting SOURCE_DATE_EPOCH to ${SOURCE_DATE_EPOCH} for reproducible builds"
+  # Write the src/version.json file with current git commit info
+  python3 ${rootfs_overlay}/opt/src/seedsigner/resources/version.py || exit
+  echo "Version info: "
+  cat ${rootfs_overlay}/opt/src/version.json
 
   cd -
   deactivate

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -51,13 +51,9 @@ download_app_repo() {
     cd ${rootfs_overlay}/opt/
     git reset --hard "${seedsigner_app_repo_commit_id}"
     cd -
-    # Provide env var to the version.py script used below
-    export SEEDSIGNER_VERSION_NAME=${seedsigner_app_repo_commit_id}
   else
     echo "cloning repo ${seedsigner_app_repo} with branch ${seedsigner_app_repo_branch}"
     git clone --recurse-submodules --depth 1 -b "${seedsigner_app_repo_branch}" "${seedsigner_app_repo}" "${rootfs_overlay}/opt/" || exit
-    # Provide env var to the version.py script used below
-    export SEEDSIGNER_VERSION_NAME=${seedsigner_app_repo_branch}
   fi
 
   # create virtual env to compile translation files
@@ -73,10 +69,12 @@ download_app_repo() {
   # return to previous directory
   cd -
 
-  # Write the src/seedsigner/version.json file.
-  cd ${rootfs_overlay}/opt/src
-  python3 seedsigner/helpers/version.py || exit
-  cat seedsigner/version.json
+  # Write the src/seedsigner/version.json file. Relies on `git` shell commands; must be
+  # run before removing the .git directory.
+  cd ${rootfs_overlay}/opt
+  export SEEDSIGNER_OS_BUILDER=1
+  python3 tools/write_versionfile.py || exit
+  cat src/seedsigner/version.json
 
   # Return to previous directory
   cd -

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -78,12 +78,6 @@ download_app_repo() {
   python3 seedsigner/helpers/version.py || exit
   cat seedsigner/version.json
 
-  # DEBUGGING
-  cat ../.git/HEAD
-  echo | ls ../.git
-  echo | ls ../.git/refs
-  echo | ls ../.git/refs/tags
-
   # Return to previous directory
   cd -
   deactivate

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -65,6 +65,11 @@ download_app_repo() {
   # remove any existing binary mo files if they exist
   rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/l10n/**/**/*.mo
   python3 setup.py compile_catalog || exit
+
+  # Set the buildroot SOURCE_DATE_EPOCH to mark all files with last commit date for reproducible builds
+  export SOURCE_DATE_EPOCH=$(git log -1 --format=%at 2> /dev/null)
+  echo "Setting SOURCE_DATE_EPOCH to ${SOURCE_DATE_EPOCH} for reproducible builds"
+
   cd -
   deactivate
 

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -79,10 +79,6 @@ download_app_repo() {
   cd -
   deactivate
 
-  # Temporarily relocate .git files used for Version info
-  mv ${rootfs_overlay}/opt/.git/HEAD ${cur_dir}/HEAD
-  mv ${rootfs_overlay}/opt/.git/refs/tags ${cur_dir}/.
-
   # Delete unnecessary files to save space
   # folders
   rm -rf ${rootfs_overlay}/opt/.github
@@ -109,14 +105,6 @@ download_app_repo() {
   rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/LICENSE
   rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/README.md
   rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/l10n/**/*.po
-
-  # Restore the .git files used for Version info
-  mkdir -p ${rootfs_overlay}/opt/.git/refs
-  mv ${cur_dir}/HEAD ${rootfs_overlay}/opt/.git/HEAD
-  mv ${cur_dir}/tags ${rootfs_overlay}/opt/.git/refs/.
-  ls ${rootfs_overlay}/opt/.git
-  cat ${rootfs_overlay}/opt/.git/HEAD
-  ls ${rootfs_overlay}/opt/.git/refs/tags
 }
 
 build_image() {

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -75,7 +75,6 @@ download_app_repo() {
 
   # Write the src/seedsigner/version.json file.
   cd ${rootfs_overlay}/opt/src
-  echo $SEEDSIGNER_VERSION_NAME
   python3 seedsigner/helpers/version.py || exit
   cat seedsigner/version.json
 

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -68,6 +68,10 @@ download_app_repo() {
   cd -
   deactivate
 
+  # Temporarily relocate .git files used for Version info
+  mv ${rootfs_overlay}/opt/.git/HEAD ${cur_dir}/HEAD
+  mv ${rootfs_overlay}/opt/.git/refs/tags ${cur_dir}/.
+
   # Delete unnecessary files to save space
   # folders
   rm -rf ${rootfs_overlay}/opt/.github
@@ -93,7 +97,12 @@ download_app_repo() {
 
   rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/LICENSE
   rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/README.md
-  rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/l10n/**/**/*.po
+  rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/l10n/**/*.po
+
+  # Restore the .git files used for Version info
+  mkdir -p ${rootfs_overlay}/opt/.git/refs
+  mv ${cur_dir}/HEAD ${rootfs_overlay}/opt/.git/HEAD
+  mv ${cur_dir}/tags ${rootfs_overlay}/opt/.git/refs/.
 }
 
 build_image() {

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -67,9 +67,10 @@ download_app_repo() {
   python3 setup.py compile_catalog || exit
 
   # Write the src/version.json file with current git commit info
-  python3 ${rootfs_overlay}/opt/src/seedsigner/helpers/version.py || exit
+  cd src
+  python3 seedsigner/helpers/version.py || exit
   echo "Version info: "
-  cat ${rootfs_overlay}/opt/src/version.json
+  cat ${rootfs_overlay}/opt/src/seedsigner/version.json
 
   cd -
   deactivate

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -66,11 +66,12 @@ download_app_repo() {
   rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/l10n/**/**/*.mo
   python3 setup.py compile_catalog || exit
 
-  # Write the src/version.json file with current git commit info
+  # Write the src/seedsigner/version.json file (reads the current git tag, branch, or
+  # commit hash; and the most recent last modified python file timestamp)
   cd src
   python3 seedsigner/helpers/version.py || exit
   echo "Version info: "
-  cat ${rootfs_overlay}/opt/src/seedsigner/version.json
+  cat seedsigner/version.json
 
   cd -
   deactivate

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -69,8 +69,9 @@ download_app_repo() {
   # return to previous directory
   cd -
 
-  # Write the src/seedsigner/version.json file (reads the current git tag, branch, or
-  # commit hash; and the most recent last modified python file timestamp)
+  # Write the src/seedsigner/version.json file. Reads the current git tag, branch, or
+  # commit hash from .git/HEAD. Pulls the last commit date from `git log`.
+  git fetch --tags
   cd ${rootfs_overlay}/opt/src
   python3 seedsigner/helpers/version.py || exit
   cat seedsigner/version.json

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -51,12 +51,13 @@ download_app_repo() {
     cd ${rootfs_overlay}/opt/
     git reset --hard "${seedsigner_app_repo_commit_id}"
     cd -
+    # Provide env var to the version.py script used below
+    export SEEDSIGNER_VERSION_NAME="${seedsigner_app_repo_commit_id}"
   else
     echo "cloning repo ${seedsigner_app_repo} with branch ${seedsigner_app_repo_branch}"
-    git clone --recurse-submodules "${seedsigner_app_repo}" "${rootfs_overlay}/opt/" || exit
-    cd ${rootfs_overlay}/opt/
-    git checkout "${seedsigner_app_repo_branch}" || exit
-    cd -
+    git clone --recurse-submodules --depth 1 -b "${seedsigner_app_repo_branch}" "${seedsigner_app_repo}" "${rootfs_overlay}/opt/" || exit
+    # Provide env var to the version.py script used below
+    export SEEDSIGNER_VERSION_NAME="${seedsigner_app_repo_branch}"
   fi
 
   # create virtual env to compile translation files

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -67,7 +67,7 @@ download_app_repo() {
   python3 setup.py compile_catalog || exit
 
   # Write the src/version.json file with current git commit info
-  python3 ${rootfs_overlay}/opt/src/seedsigner/resources/version.py || exit
+  python3 ${rootfs_overlay}/opt/src/seedsigner/helpers/version.py || exit
   echo "Version info: "
   cat ${rootfs_overlay}/opt/src/version.json
 

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -107,7 +107,7 @@ download_app_repo() {
 
   rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/LICENSE
   rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/README.md
-  rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/l10n/**/*.po
+  rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/l10n/**/**/*.po
 }
 
 build_image() {

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -74,6 +74,12 @@ download_app_repo() {
   python3 seedsigner/helpers/version.py || exit
   cat seedsigner/version.json
 
+  # DEBUGGING
+  cat ../.git/HEAD
+  echo | ls ../.git
+  echo | ls ../.git/refs
+  echo | ls ../.git/refs/tags
+
   # Return to previous directory
   cd -
   deactivate

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -53,7 +53,7 @@ download_app_repo() {
     cd -
   else
     echo "cloning repo ${seedsigner_app_repo} with branch ${seedsigner_app_repo_branch}"
-    git clone --recurse-submodules --depth 1 -b "${seedsigner_app_repo_branch}" "${seedsigner_app_repo}" "${rootfs_overlay}/opt/" || exit
+    git clone --recurse-submodules -b "${seedsigner_app_repo_branch}" "${seedsigner_app_repo}" "${rootfs_overlay}/opt/" || exit
   fi
 
   # create virtual env to compile translation files
@@ -71,9 +71,6 @@ download_app_repo() {
 
   # Write the src/seedsigner/version.json file.
   cd ${rootfs_overlay}/opt/src
-  # Have to make sure we have the git tags as well, otherwise building for a specific tag
-  # will just report its detached HEAD commit hash instead of the tag name.
-  git fetch --tags
   python3 seedsigner/helpers/version.py || exit
   cat seedsigner/version.json
 

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -103,6 +103,9 @@ download_app_repo() {
   mkdir -p ${rootfs_overlay}/opt/.git/refs
   mv ${cur_dir}/HEAD ${rootfs_overlay}/opt/.git/HEAD
   mv ${cur_dir}/tags ${rootfs_overlay}/opt/.git/refs/.
+  ls ${rootfs_overlay}/opt/.git
+  cat ${rootfs_overlay}/opt/.git/HEAD
+  ls ${rootfs_overlay}/opt/.git/refs/tags
 }
 
 build_image() {

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -66,13 +66,16 @@ download_app_repo() {
   rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/l10n/**/**/*.mo
   python3 setup.py compile_catalog || exit
 
+  # return to previous directory
+  cd -
+
   # Write the src/seedsigner/version.json file (reads the current git tag, branch, or
   # commit hash; and the most recent last modified python file timestamp)
-  cd src
+  cd ${rootfs_overlay}/opt/src
   python3 seedsigner/helpers/version.py || exit
-  echo "Version info: "
   cat seedsigner/version.json
 
+  # Return to previous directory
   cd -
   deactivate
 

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -69,10 +69,11 @@ download_app_repo() {
   # return to previous directory
   cd -
 
-  # Write the src/seedsigner/version.json file. Reads the current git tag, branch, or
-  # commit hash from .git/HEAD. Pulls the last commit date from `git log`.
-  git fetch --tags
+  # Write the src/seedsigner/version.json file.
   cd ${rootfs_overlay}/opt/src
+  # Have to make sure we have the git tags as well, otherwise building for a specific tag
+  # will just report its detached HEAD commit hash instead of the tag name.
+  git fetch --tags
   python3 seedsigner/helpers/version.py || exit
   cat seedsigner/version.json
 


### PR DESCRIPTION
Depends on https://github.com/SeedSigner/seedsigner/pull/858

The SeedSigner OS side of this new feature is very simple. We just need to run the `tools/write_versionfile.py` script while the `.git/` files are still available.

The `SEEDSIGNER_OS_BUILDER` env var tells the `Version` code that we're in the SeedSigner OS build environment.

The resulting `version.json` file is included in the final image as the "source of truth" for the `Version` display in SeedSigner.