### PR TITLE
[Fix] update for loop around extract_characters_from_babel_mo.py script

### DIFF
--- a/opt/build.sh
+++ b/opt/build.sh
@@ -58,11 +58,12 @@ compile_translations_and_fonts() {
   # generate messages.mo files for each translation
   python3 setup.py compile_catalog || exit
 
-
   # extract characters from all messages.mo translations into all_chars shell variable
   all_chars=""
-  for f in "${ss_translations_repo}/l10n/"**"/LC_MESSAGES/messages.mo"; do
-    output_chars=$(python3 ${ss_translations_repo}/tools/extract_characters_from_babel_mo.py $f)
+  for f in ${ss_translations_repo}/l10n/*/LC_MESSAGES/messages.mo; do
+    # extract just the locale name from the path (e.g. "ca" from ".../l10n/ca/LC_MESSAGES/messages.mo")
+    locale=$(basename "$(dirname "$(dirname "$f")")")
+    output_chars=$(cd ${ss_translations_repo}/tools && python3 extract_characters_from_babel_mo.py "$locale")
     all_chars="${all_chars}${output_chars}"
   done
 

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -63,7 +63,7 @@ compile_translations_and_fonts() {
   for f in ${ss_translations_repo}/l10n/*/LC_MESSAGES/messages.mo; do
     # extract just the locale name from the path (e.g. "ca" from ".../l10n/ca/LC_MESSAGES/messages.mo")
     locale=$(basename "$(dirname "$(dirname "$f")")")
-    output_chars=$(cd ${ss_translations_repo}/tools && python3 extract_characters_from_babel_mo.py "$locale")
+    output_chars=$(cd ${ss_translations_repo}/tools && python3 extract_characters_from_babel_mo.py "$locale") || echo "Warning: failed to extract chars for locale: $locale" >&2
     all_chars="${all_chars}${output_chars}"
   done
 


### PR DESCRIPTION
PR https://github.com/SeedSigner/seedsigner-translations/pull/48 included a late addition to tools/extract_characters_from_babel_mo.py. It was missed that this script expects just the locale name (e.g. ca) as its first argument, not the full file path to the .mo file. The build script was passing the full path, causing the character extraction step to fail and halting the entire build.

This PR fixes the invocation to pass the correct locale argument and run the script from the proper working directory. It also prevents a failure in extract_characters_from_babel_mo.py from halting the build. Instead the error is logged and the build continues.