### PR TITLE
[Feature] Enable build via Podman and Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,4 @@ RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
 RUN locale-gen en_US.UTF-8
 
 WORKDIR /opt
-ENTRYPOINT ["./build.sh"]
+ENTRYPOINT ["/bin/bash", "-c", "./build.sh $SS_ARGS"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,5 @@ services:
       - ./images:/images
       - ./.ccache:/root/.cache/ccache
       - ./.buildroot-ccache:/root/.buildroot-ccache
-    command: "${SS_ARGS:---no-op}"
+    environment:
+      - SS_ARGS=${SS_ARGS:---no-op}


### PR DESCRIPTION
What is [Podman](https://podman.io/)? A: Its a free & open source container tool that can be used in place of Docker.

This minor change is to make small changes to the `Dockerfile` and `docker-compose.yml` file to allow the build to work for both Docker and Podman. Podman still uses the `Dockerfile` and `docker-compose.yml` for build config.

Dockerfile change:

Updating the entry point to `ENTRYPOINT ["/bin/bash", "-c", "./build.sh $SS_ARGS"]` from `ENTRYPOINT ["./build.sh"]`. This new entrypoint wraps the build script in `/bin/bash -c`, which invokes a shell that expands `$SS_ARGS` before passing the arguments to `build.sh`. This allows moving the $SS_ARGS command as an environment variable instead of a command.

The docker-compose.yml change:

```
environment:
    - SS_ARGS=${SS_ARGS:---no-op}
```
Shifts how build arguments are passed from a command override to an environment variable. Before: SS_ARGS was expanded on the host side by docker-compose and passed as a command argument, which overrides the container's ENTRYPOINT arguments. This worked with the old ENTRYPOINT ["./build.sh"] since Docker appends command values as arguments to the entrypoint. After: SS_ARGS is passed into the container as an environment variable. The updated ENTRYPOINT (/bin/bash -c "./build.sh $SS_ARGS") then expands it inside the container at runtime.

The default value ${SS_ARGS:---no-op} is preserved. If you don't set SS_ARGS on the host, it defaults to --no-op, which starts the container without running a build (useful for the interactive dev workflow where you docker exec in and run builds manually).


Reproducible build steps with Podman on a mac:

```
# Install Podman (https://github.com/containers/podman)
brew install podman

# Check podman version, expecting 5.8.0 or higher
podman --version

# Initialize VM Machine
# Half of logical CPU cores
CPUS=$(( $(sysctl -n hw.logicalcpu) / 2 ))
# Half of total system RAM
MEMORY=$(( $(sysctl -n hw.memsize) / 1024 / 1024 / 2 ))
# 40 GB Disk
DISK=40

# Creates a lightweight Linux VM
podman machine init --cpus $CPUS --memory $MEMORY --disk-size $DISK --now

# Starts the lightweigh linux VM to create the container in
podman machine start

# Checks to see if the podman machine is running
podman info

export DOCKER_DEFAULT_PLATFORM=linux/amd64
git submodule init && git submodule update

SS_ARGS="--pi0 --app-repo=https://github.com/seedsigner/seedsigner.git --app-commit-id=eecb26e" podman-compose up --force-recreate --build
cd images
shasum -a 256 seedsigner_os.*eecb26e*

# Cleanup podman containers
podman rm -af

# Cleanup podman images
podman rmi -af

# Cleanup podman volumes
podman volume rm -a

# Stop podman machine
podman machine stop

# Cleanup podman machine
podman machine rm
```

Equivalent Docker command (skipping install steps):
```
export DOCKER_DEFAULT_PLATFORM=linux/amd64
git submodule init && git submodule update
SS_ARGS="--pi0 --app-repo=https://github.com/seedsigner/seedsigner.git --app-commit-id=eecb26e" docker-compose up --force-recreate --build
cd images
shasum -a 256 seedsigner_os.*eecb26e*
```