### PR TITLE
Add `nodirty` FAT mount option so booting never modifies the SD card

### DIFF
--- a/opt/patches/linux/0001-fat-add-nodirty-mount-option.patch
+++ b/opt/patches/linux/0001-fat-add-nodirty-mount-option.patch
@@ -1,0 +1,78 @@
+fat: add "nodirty" mount option to never write the volume dirty flag
+
+SeedSigner OS mounts the SD card's FAT boot partition read-write so the
+app can persist settings. On every read-write mount the FAT driver's
+fat_set_state() sets the volume dirty flag (boot sector offset 0x25 on
+FAT12/16, 0x41 on FAT32) and clears it again on clean unmount. Since
+SeedSigner devices are powered off by cutting power, the flag is set
+once and never cleared, which breaks byte-for-byte verification of the
+card against the flashed image.
+
+With "nodirty", fat_set_state() becomes a no-op: the on-disk dirty flag
+is never set or cleared, so a mount (and unmount) writes nothing at all.
+File writes behave as usual. Without the option, behavior is unchanged.
+
+Patch applies to raspberrypi/linux 14b35093ca68 (rpi-5.15.y, v5.15.92).
+
+Signed-off-by: SeedSigner OS build patch
+
+--- a/fs/fat/fat.h	2026-07-11 15:19:52
++++ b/fs/fat/fat.h	2026-07-11 15:19:52
+@@ -51,7 +51,8 @@
+ 		 tz_set:1,	   /* Filesystem timestamps' offset set */
+ 		 rodir:1,	   /* allow ATTR_RO for directory */
+ 		 discard:1,	   /* Issue discard requests on deletions */
+-		 dos1xfloppy:1;	   /* Assume default BPB for DOS 1.x floppies */
++		 dos1xfloppy:1,	   /* Assume default BPB for DOS 1.x floppies */
++		 nodirty:1;	   /* Never write the volume dirty flag */
+ };
+ 
+ #define FAT_HASH_BITS	8
+--- a/fs/fat/inode.c	2026-07-11 15:19:52
++++ b/fs/fat/inode.c	2026-07-11 15:19:52
+@@ -669,6 +669,10 @@
+ 	struct buffer_head *bh;
+ 	struct fat_boot_sector *b;
+ 	struct msdos_sb_info *sbi = MSDOS_SB(sb);
++
++	/* never touch the on-disk dirty flag if nodirty is set */
++	if (sbi->options.nodirty)
++		return;
+ 
+ 	/* do not change any thing if mounted read only */
+ 	if (sb_rdonly(sb) && !force)
+@@ -1025,6 +1029,8 @@
+ 		seq_puts(m, ",discard");
+ 	if (opts->dos1xfloppy)
+ 		seq_puts(m, ",dos1xfloppy");
++	if (opts->nodirty)
++		seq_puts(m, ",nodirty");
+ 
+ 	return 0;
+ }
+@@ -1040,6 +1046,7 @@
+ 	Opt_obsolete, Opt_flush, Opt_tz_utc, Opt_rodir, Opt_err_cont,
+ 	Opt_err_panic, Opt_err_ro, Opt_discard, Opt_nfs, Opt_time_offset,
+ 	Opt_nfs_stale_rw, Opt_nfs_nostale_ro, Opt_err, Opt_dos1xfloppy,
++	Opt_nodirty,
+ };
+ 
+ static const match_table_t fat_tokens = {
+@@ -1073,6 +1080,7 @@
+ 	{Opt_nfs_stale_rw, "nfs=stale_rw"},
+ 	{Opt_nfs_nostale_ro, "nfs=nostale_ro"},
+ 	{Opt_dos1xfloppy, "dos1xfloppy"},
++	{Opt_nodirty, "nodirty"},
+ 	{Opt_obsolete, "conv=binary"},
+ 	{Opt_obsolete, "conv=text"},
+ 	{Opt_obsolete, "conv=auto"},
+@@ -1285,6 +1293,9 @@
+ 		case Opt_dos1xfloppy:
+ 			opts->dos1xfloppy = 1;
+ 			break;
++		case Opt_nodirty:
++			opts->nodirty = 1;
++			break;
+ 
+ 		/* msdos specific */
+ 		case Opt_dots:

--- a/opt/rootfs-overlay/etc/mdev/mdev.sh
+++ b/opt/rootfs-overlay/etc/mdev/mdev.sh
@@ -4,7 +4,9 @@ DEVNAME="/dev/$MDEV"
 
 if [ $ACTION == "add" ] && [ -n "$DEVNAME" ]; then
     mkdir -p /mnt/microsd
-    mount -o sync $DEVNAME /mnt/microsd
+    # nodirty (custom kernel patch) keeps the mount from writing the FAT
+    # volume dirty flag; fall back for kernels without the patch (dev boards)
+    mount -o sync,nodirty $DEVNAME /mnt/microsd || mount -o sync $DEVNAME /mnt/microsd
     echo -n "add" > /tmp/mdev_fifo
 elif [ $ACTION == "remove" ] && [ -n "$DEVNAME" ]; then
     umount /mnt/microsd


### PR DESCRIPTION
### Problem

A freshly flashed SeedSigner OS card is byte-identical to the release image but after its first boot it no longer matches. The cause is a single byte on every read-write mount. Linux mounts the volume and sets a dirty flag (boot-sector offset 0x25 on FAT12/16). The flag is normally cleared on clean unmount, but SeedSigner devices are powered off by cutting power.

### Fix

Identified with the help of Claude.

1. **`opt/patches/linux/0001-fat-add-nodirty-mount-option.patch`**: adds a `nodirty` mount option to the kernel FAT driver. When set, `fat_set_state()` becomes a no-op, so mounting and unmounting write nothing at all. Behavior without the option is unchanged. The patch is picked up automatically by the existing `BR2_GLOBAL_PATCH_DIR` on all four release boards. Instead of removing the calls to fat_set_state(), the patch changes the function itself to do nothing when the `nodirty` option is active. Line 1885 still executes on every mount; it just returns immediately without touching the disk. The `if (sbi->options.nodirty)` check breaks/returns from the `fat_set_state()` function early if the `nodirty` option is set. The `fat_set_stat()` function is the only place in the driver that reads/writes the dirty flag

2. **`opt/rootfs-overlay/etc/mdev/mdev.sh`** adds the nodirty option to the mount command and falls back to plain `-o sync` if the option is rejected. The fallback is required for the dev-board defconfigs that don't have `BR2_GLOBAL_PATCH_DIR` set.

Note: Persistent Settings is unaffected: the card is still mounted read-write and `settings.json` saves work exactly as before.

### Result (hardware-verified)

Flash → verify hash → boot to main menu on a real Pi Zero → pull power → re-hash on a Mac: **the card reads back byte-identical to the image** (`shasum -a 256` match), across repeated boot cycles.

## How to test

All `dd`/hash commands need `sudo`. Steps are for macOS; on Linux, skip the fstab step and just don't mount the card (or disable your desktop's automounter).

### 0. One-time macOS setup - block the automount

macOS auto-mounts FAT volumes read-write within ~2 s of the card appearing and immediately writes `.fseventsd` onto it, which corrupts verification regardless of this patch. Block it via `/etc/fstab` (`sudo vifs`):

```
LABEL=SEEDSIGNROS none auto ro,noauto
```

The type field **must be `auto`** entries with type `msdos` are silently ignored (macOS bug). One line covers every SeedSigner release card (shared volume label).

### 1. Build the image

```
SS_ARGS="--pi0 --app-branch=0.8.7" docker compose up --force-recreate --build
```

### 2. Identify the card

```
diskutil list
```

Note the identifier (e.g. `disk8`) **the next steps destroy that disk**. Substitute it below.

### 3. Zero the entire card (optional but makes verification airtight)

```
diskutil unmountDisk force disk8
sudo dd if=/dev/zero of=/dev/rdisk8 bs=1m
```

dd ending with "end of device" is normal. Click **Ignore** on the "disk not readable" dialog.

### 4. Flash and verify the card matches the image

```
sudo dd if=images/seedsigner_os.0.8.7.pi0.img of=/dev/rdisk8 bs=1m
sync
sudo dd if=/dev/rdisk8 bs=1m count=50 | shasum -a 256
shasum -a 256 images/seedsigner_os.0.8.7.pi0.img
```

Both hashes must match (`count=50` = the 50 MiB image size).

### 5. Eject and use the device

```
diskutil eject disk8
```

Boot the SeedSigner to the main menu, navigate around, pull power. (Don't enable Persistent Settings for this test)

### 6. Re-verify after use

Re-insert the card. Confirm it did **not** mount (`mount | grep disk8` → nothing), then:

```
sudo dd if=/dev/rdisk8 bs=1m count=50 | shasum -a 256
```

**Expected: the exact image hash from step 4.** Repeat steps 5–6 as many times as you like and the hash should never change.