### PR TITLE
Persist Buildroot download cache across builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.DS_Store
 .buildroot-ccache/
+.buildroot_dl/
 .ccache/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,5 @@ services:
       - ./images:/images
       - ./.ccache:/root/.cache/ccache
       - ./.buildroot-ccache:/root/.buildroot-ccache
+      - ./.buildroot_dl:/buildroot_dl
     command: "${SS_ARGS:---no-op}"


### PR DESCRIPTION
This adds a Docker volume mount for .buildroot_dl so downloaded package sources survive across container runs. The directory is also added to .gitignore. This avoids re-downloading sources on every clean build.