### PR TITLE
Fix `version.json` not being written on `--skip-repo` (CI) builds

### DIFF
--- a/opt/build.sh
+++ b/opt/build.sh
@@ -87,16 +87,38 @@ compile_translations_and_fonts() {
   # remove original font files
   rm -f ${ss_translations_repo}/fonts/NotoSans*Regular-Original*ttf
 
-  # Write src/seedsigner/version.json. Must run before download_app_repo removes
-  # .git and tools/ below. Runs here, inside the venv, because write_versionfile.py
-  # imports seedsigner.helpers.version, which `pip install -e .` above provides.
-  export SEEDSIGNER_OS_BUILDER=1
-  python3 tools/write_versionfile.py || exit
-  cat src/seedsigner/version.json
-
   cd -
   deactivate
 
+}
+
+write_version_json() {
+  # Writes ${rootfs_overlay}/opt/src/seedsigner/version.json, which SeedSigner OS reads
+  # at runtime. A missing or incomplete file makes the app raise at the splash screen,
+  # so failures here are fatal.
+  # Must run while .git/ and tools/ are still present (delete_unnecessary_files drops them).
+  app_dir="${rootfs_overlay}/opt"
+
+  if [ -f "${app_dir}/src/seedsigner/version.json" ]; then
+    # Already written: either by an earlier build_image call (--all) or by the caller.
+    echo "version.json already present, leaving as-is"
+    cat "${app_dir}/src/seedsigner/version.json"
+    return
+  fi
+
+  if [ ! -f "${app_dir}/tools/write_versionfile.py" ]; then
+    echo "ERROR: ${app_dir}/tools/write_versionfile.py not found; cannot write version.json" >&2
+    exit 1
+  fi
+
+  # In CI the overlay is a bind-mounted host checkout owned by a different uid than the
+  # root user in this container. git refuses such repos ("dubious ownership") and
+  # version.py silently discards the error, yielding a version.json that bricks boot.
+  git config --global --add safe.directory "$(cd "${app_dir}" && pwd)"
+
+  # PYTHONPATH=src is enough; write_versionfile.py's imports are stdlib-only.
+  export SEEDSIGNER_OS_BUILDER=1
+  (cd "${app_dir}" && PYTHONPATH=src python3 tools/write_versionfile.py) || exit
 }
 
 download_app_repo() {
@@ -119,8 +141,12 @@ download_app_repo() {
   fi
 
   compile_translations_and_fonts
+}
 
-  # Delete unnecessary files to save space
+delete_unnecessary_files() {
+  # Delete unnecessary files to save space. Runs independently of download_app_repo so
+  # that --skip-repo builds (CI, which populates rootfs-overlay/opt itself) are trimmed
+  # too. Must run after write_version_json, which needs .git/ and tools/.
   # folders
   rm -rf ${rootfs_overlay}/opt/.github
   rm -rf ${rootfs_overlay}/opt/docker
@@ -177,6 +203,11 @@ build_image() {
   if [ "${3}" != "skip-repo" ]; then
     download_app_repo
   fi
+
+  # Both run unconditionally so --skip-repo builds get the same treatment. Order
+  # matters: write_version_json needs the .git/ and tools/ that the other removes.
+  write_version_json
+  delete_unnecessary_files
 
   # Setup external tree
   #make BR2_EXTERNAL="../${config_dir}/" O="${build_dir}" -C ./buildroot/ #2> /dev/null > /dev/null


### PR DESCRIPTION
## Problem

Images produced by the SeedSigner CI build action hang during boot. The logo appears, but startup never continues. The action itself passes, so the failure only becomes visible after the image is flashed to hardware.

SeedSigner/seedsigner#858 added a Version screen that reads `src/seedsigner/version.json` at runtime and raises an exception if the file is missing or incomplete. `Controller.start()` calls `OpeningSplashView().run()` without a `try/except`, so that exception terminates the app. The display keeps showing its last frame, making the device look like it has hung.

Current CI build steps do not create the `version.json` file.

## Cause

The companion change in #102 put the `write_versionfile.py` call inside `compile_translations_and_fonts()`, which is only reached through `download_app_repo()`:

```bash
if [ "${3}" != "skip-repo" ]; then
  download_app_repo
fi
```

The SeedSigner CI action checks the application out directly into `rootfs-overlay/opt`, then runs the container with `--skip-repo`. This skips `download_app_repo()` and everything it would normally run.

The Pi Zero build log confirms it. There are no references to `write_versionfile`, `pyftsubset`, or `git clone` anywhere in the run.

Local builds are unaffected. Without `--skip-repo`, they still call `download_app_repo()` and write `version.json` as expected.

## Fix

- Move the version-writing step out of `compile_translations_and_fonts()` and into `write_version_json()`.
- Move cleanup out of `download_app_repo()` and into `delete_unnecessary_files()`.
- Call both functions from `build_image()` regardless of whether `--skip-repo` is set.
- Write the version file before cleanup because the script needs `.git/` and `tools/`, both of which cleanup removes.
- Have `write_version_json()` do nothing if `version.json` already exists. This is required for `--all`, where only the first `build_image()` call clones the repository.
- Set Git's `safe.directory` before writing the version file. In CI, the overlay is a bind-mounted host checkout owned by a different UID than the container's root user. Git refuses to read the repository otherwise. `version.py` hides that error with `2> /dev/null`, so the build stays green but writes a null timestamp. The resulting file still fails at boot.
- Remove the virtual environment dependency. `PYTHONPATH=src` is sufficient because `version.py` only imports standard library modules.

## Requires companion PR

This needs the matching SeedSigner PR SeedSigner/seedsigner#956 that change stops `build.yml` from deleting `.git/` and `tools/` before the container starts, and adds a `jq` check that fails the build if `version.json` is invalid.

The two PRs need to merge together. The `build.yml` change alone preserves the required files but leaves nothing to write `version.json`. This PR alone still receives a checkout with `.git/` and `tools/` already deleted.

## Verification

Simulated both the CI checkout state (`checkout -B dev origin/dev`) and the manual clone (`--depth 1 -b dev`). I also did a local build with no issues. Both produce a complete file:

```json
{ "name": "dev", "fork": "SeedSigner", "short_commit_hash": "5c748cc", "timestamp": "2026-07-22T03:52:25" }
```

A tagged build yields `"name": "v0.8.7"`, so `is_release_image()` still behaves correctly.

The splash screen currently shows the branch name (`dev`) because `version.py` resolves the branch before checking for a tag or falling back to the commit hash. 