### PR TITLE
[Enhancement] Remove embit's pure-Python secp256k1 fallback

### DIFF
--- a/opt/pi0-dev/board/post-build.sh
+++ b/opt/pi0-dev/board/post-build.sh
@@ -61,6 +61,13 @@ rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp25
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_linux_x86_64.so
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_windows_amd64.dll
 
+# Remove embit's pure-Python secp256k1 fallback: we must run only on the pre-compiled
+# libsecp256k1 C code or not at all. We explicitly opt for hard failure over silent
+# fallback.
+# We must delete both the .py and the .pyc to fully remove the fallback.
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.py
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.pyc
+
 # Dev convenience: make `python3 -m venv DIR` produce a usable venv by default.
 # This image's Python is built --without-ensurepip and carries the app's native
 # deps (PIL/numpy/embit/...) only in the system site-packages, so the two useful

--- a/opt/pi0/board/post-build.sh
+++ b/opt/pi0/board/post-build.sh
@@ -37,6 +37,13 @@ rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp25
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_linux_x86_64.so
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_windows_amd64.dll
 
+# Remove embit's pure-Python secp256k1 fallback: we must run only on the pre-compiled
+# libsecp256k1 C code or not at all. We explicitly opt for hard failure over silent
+# fallback.
+# We must delete both the .py and the .pyc to fully remove the fallback.
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.py
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.pyc
+
 # Clean up tests/docs in other python included libs
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/pyzbar/tests
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/qrcode/tests

--- a/opt/pi02w-dev/board/post-build.sh
+++ b/opt/pi02w-dev/board/post-build.sh
@@ -61,6 +61,13 @@ rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp25
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_linux_x86_64.so
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_windows_amd64.dll
 
+# Remove embit's pure-Python secp256k1 fallback: we must run only on the pre-compiled
+# libsecp256k1 C code or not at all. We explicitly opt for hard failure over silent
+# fallback.
+# We must delete both the .py and the .pyc to fully remove the fallback.
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.py
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.pyc
+
 # Dev convenience: make `python3 -m venv DIR` produce a usable venv by default.
 # This image's Python is built --without-ensurepip and carries the app's native
 # deps (PIL/numpy/embit/...) only in the system site-packages, so the two useful

--- a/opt/pi02w/board/post-build.sh
+++ b/opt/pi02w/board/post-build.sh
@@ -37,6 +37,13 @@ rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp25
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_linux_x86_64.so
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_windows_amd64.dll
 
+# Remove embit's pure-Python secp256k1 fallback: we must run only on the pre-compiled
+# libsecp256k1 C code or not at all. We explicitly opt for hard failure over silent
+# fallback.
+# We must delete both the .py and the .pyc to fully remove the fallback.
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.py
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.pyc
+
 # Clean up tests/docs in other python included libs
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/pyzbar/tests
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/qrcode/tests

--- a/opt/pi2-dev/board/post-build.sh
+++ b/opt/pi2-dev/board/post-build.sh
@@ -61,6 +61,13 @@ rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp25
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_linux_x86_64.so
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_windows_amd64.dll
 
+# Remove embit's pure-Python secp256k1 fallback: we must run only on the pre-compiled
+# libsecp256k1 C code or not at all. We explicitly opt for hard failure over silent
+# fallback.
+# We must delete both the .py and the .pyc to fully remove the fallback.
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.py
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.pyc
+
 # Dev convenience: make `python3 -m venv DIR` produce a usable venv by default.
 # This image's Python is built --without-ensurepip and carries the app's native
 # deps (PIL/numpy/embit/...) only in the system site-packages, so the two useful

--- a/opt/pi2/board/post-build.sh
+++ b/opt/pi2/board/post-build.sh
@@ -37,6 +37,13 @@ rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp25
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_linux_x86_64.so
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_windows_amd64.dll
 
+# Remove embit's pure-Python secp256k1 fallback: we must run only on the pre-compiled
+# libsecp256k1 C code or not at all. We explicitly opt for hard failure over silent
+# fallback.
+# We must delete both the .py and the .pyc to fully remove the fallback.
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.py
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.pyc
+
 # Clean up tests/docs in other python included libs
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/pyzbar/tests
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/qrcode/tests

--- a/opt/pi4-dev/board/post-build.sh
+++ b/opt/pi4-dev/board/post-build.sh
@@ -61,6 +61,13 @@ rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp25
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_linux_x86_64.so
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_windows_amd64.dll
 
+# Remove embit's pure-Python secp256k1 fallback: we must run only on the pre-compiled
+# libsecp256k1 C code or not at all. We explicitly opt for hard failure over silent
+# fallback.
+# We must delete both the .py and the .pyc to fully remove the fallback.
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.py
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.pyc
+
 # Dev convenience: make `python3 -m venv DIR` produce a usable venv by default.
 # This image's Python is built --without-ensurepip and carries the app's native
 # deps (PIL/numpy/embit/...) only in the system site-packages, so the two useful

--- a/opt/pi4/board/post-build.sh
+++ b/opt/pi4/board/post-build.sh
@@ -37,6 +37,13 @@ rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp25
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_linux_x86_64.so
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_windows_amd64.dll
 
+# Remove embit's pure-Python secp256k1 fallback: we must run only on the pre-compiled
+# libsecp256k1 C code or not at all. We explicitly opt for hard failure over silent
+# fallback.
+# We must delete both the .py and the .pyc to fully remove the fallback.
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.py
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.pyc
+
 # Clean up tests/docs in other python included libs
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/pyzbar/tests
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/qrcode/tests


### PR DESCRIPTION
The following is largely a Claude summary of our work, with light edits by me:

---

## Problem

`embit/util/secp256k1.py` selects its implementation like this:

```python
try:
    from .ctypes_secp256k1 import *
except:
    from .py_secp256k1 import *
```

The fallback import is unguarded, so any failure to load libsecp256k1 (missing .so, wrong architecture, corrupt file) silently downgrades the device to a pure-Python implementation. It boots, it looks healthy, and it signs.

We want the opposite behavior: if the pre-compiled library cannot be reached, embit should raise at import and the app should not start.

However, note that I am unaware of any bugs or security issues identified in the pure python fallback. This is strictly a defensive measure to guarantee that we are running on the compiled binary.

## Likelihood in prior releases
Claude assessments of if and when users might have encountered the pure python secp256k1 implementation:

- **0.4.x – 0.5.0:** The pure python secp256k1 was the only path.

- **0.5.1:** Very unlikely per user. The one accidental trigger would be SD corruption of the single `.so` on the writable Pi OS image. Plausible fleet-wide in aggregate, rare for any individual device.

- **0.6.0 – 0.8.7 (SeedSigner OS):** Effectively zero. The architecture always matches the bundled binaries (32-bit kernels on all boards), and the rootfs is a CRC-checked initramfs. SD corruption fails loudly at boot rather than silently at library load. The only remaining triggers are a `dlopen` failure under memory exhaustion at startup or a post-boot RAM bit-flip, both marginal.

## Change

Each board's `post-build.sh` deletes `py_secp256k1.py` and `py_secp256k1.pyc` from the target tree. With the module gone, the `except` branch raises `ModuleNotFoundError` instead of falling back.

Note: **No `__pycache__` form to delete**. Buildroot's default `BR2_PACKAGE_PYTHON3_PYC_ONLY` passes `-b`, producing the flat `.pyc` beside the `.py`. 

### The fallback is gone from the shipped image

Extracted the initramfs from the resulting image and compared it against the published 0.8.7 pi0 image:

| `embit/util/` | 0.8.7 (published) | this branch |
| --- | --- | --- |
| `py_secp256k1.pyc` | 17,609 bytes | **absent** |
| `ctypes_secp256k1.pyc` | 44,027 bytes | 44,027 bytes |
| `secp256k1.pyc` | 371 bytes | 371 bytes |

The unchanged sizes on the other two confirm the change removes exactly one thing and disturbs nothing else. A `find` for `py_secp256k1.*` across the whole target tree returns nothing.


## Additional information

Developed by Claude with human review, iteration, and edits.

Additional separate review pass using Fable 5.

This issue was responsibly disclosed by @l0rinc.