### PR TITLE
[Enhancement] verify at build time that only the compiled libsecp256k1 ships

### DIFF
--- a/opt/external-packages/python-embit/verify-secp256k1-binary.sh
+++ b/opt/external-packages/python-embit/verify-secp256k1-binary.sh
@@ -13,6 +13,20 @@
 #     fails to load, embit no longer raises -- it quietly signs with python
 #     instead, on a device that looks and behaves like a working one. Check 1.
 #
+# This is a gatekeeper for the embit version pinned in python-embit.mk, not a
+# permanent fixture. Both projects are moving the same direction: upstream embit
+# has dropped the prebuilt binaries from its recent releases, on the reasoning
+# that each application is better off compiling libsecp256k1 itself, and there is
+# an open PR there to remove the pure python fallback outright. SeedSigner
+# intends to land in the same place -- no fallback in the tree at all, and our
+# own build of libsecp256k1. At that point checks 3 and 4 describe a layout that
+# no longer exists and this script should be rewritten or retired.
+#
+# Until then it stays deliberately coupled to the layout embit ships today. An
+# embit bump will trip checks 3 and 4 rather than pass quietly, and that is the
+# intended behavior: bumping embit here is a rare and deliberate act, so the
+# build stopping is how it earns the attention it deserves.
+#
 # Usage: verify-secp256k1-binary.sh <target-dir>
 #
 # Called at the end of each board's post-build.sh -- the last thing to touch the
@@ -76,9 +90,13 @@ done
 #    drifted from the set of files embit actually installs.
 #    Same two-part shape as check 1: the scan must complete before an empty
 #    result can be read as "nothing extra".
-if ! EXTRA="$(find "${UTIL_DIR}/prebuilt" -type f \
-	! -name 'libsecp256k1_linux_armv6l.so' \
-	! -name 'libsecp256k1_linux_armv7l.so')"; then
+#    -mindepth 1 rather than -type f, so a symlink or a subdirectory counts as
+#    "something else" too, and -path rather than -name, so the two exemptions
+#    apply to those exact two entries and not to any file that merely shares
+#    their basename further down.
+if ! EXTRA="$(find "${UTIL_DIR}/prebuilt" -mindepth 1 \
+	! -path "${UTIL_DIR}/prebuilt/libsecp256k1_linux_armv6l.so" \
+	! -path "${UTIL_DIR}/prebuilt/libsecp256k1_linux_armv7l.so")"; then
 	fail "could not scan ${UTIL_DIR}/prebuilt -- see find's errors above"
 fi
 if [ -n "${EXTRA}" ]; then

--- a/opt/external-packages/python-embit/verify-secp256k1-binary.sh
+++ b/opt/external-packages/python-embit/verify-secp256k1-binary.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+#
+# embit's secp256k1 must be the pre-compiled libsecp256k1 and there must be no
+# trace of the pure python secp256k1 fallback.
+#
+# Two things can go wrong, and they are not equally visible:
+#
+#   - libsecp256k1 is missing or unusable. embit raises at import and the app
+#     never starts. Loud, but much better caught at build time than on first
+#     boot. Checks 2-4.
+#
+#   - The pure python fallback is back in the image. Now if the library ever
+#     fails to load, embit no longer raises -- it quietly signs with python
+#     instead, on a device that looks and behaves like a working one. Check 1.
+#
+# Usage: verify-secp256k1-binary.sh <target-dir>
+#
+# Called at the end of each board's post-build.sh -- the last thing to touch the
+# target tree.
+
+set -u
+set -e
+
+TARGET_DIR="${1:?usage: verify-secp256k1-binary.sh <target-dir>}"
+
+fail() {
+	echo "ERROR: verify-secp256k1-binary: $1" >&2
+	exit 1
+}
+
+# usr/lib/python3 and python3.10 are symlinks to python3.12, so resolve to the
+# one physical tree rather than globbing (which would report each file 3x).
+UTIL_DIR="$(cd "${TARGET_DIR}/usr/lib/python3/site-packages/embit/util" 2>/dev/null && pwd -P)" \
+	|| fail "embit is not installed under ${TARGET_DIR}/usr/lib/python3/site-packages"
+
+# 1. The pure-Python implementation must not be installed, as source or bytecode.
+#    Scanning the whole tree rather than the known path also catches a stray copy
+#    left anywhere else in the image. The glob deliberately covers every form the
+#    module could take: py_secp256k1.py, the flat py_secp256k1.pyc that
+#    site-packages ships, and the py_secp256k1.cpython-312.pyc that a __pycache__
+#    directory would hold.
+#
+#    Two separate failures, in this order:
+#      a) the sweep itself did not finish (find exited non-zero, e.g. a directory
+#         it could not read), so part of the tree went unexamined and a clean
+#         result would only mean "did not look there";
+#      b) the sweep finished and turned something up.
+#    (a) has to be ruled out first: an empty result from a find that died reads
+#    exactly like an empty result from a find that found nothing.
+if ! STRAYS="$(find "${TARGET_DIR}" -name 'py_secp256k1.*')"; then
+	fail "could not scan ${TARGET_DIR} for the pure-Python fallback -- see find's errors above. The scan did not cover the whole tree, so the python secp256k1 fallback's absence is unproven and the build stops here."
+fi
+if [ -n "${STRAYS}" ]; then
+	fail "pure-Python secp256k1 fallback is present in the image:
+${STRAYS}"
+fi
+
+# 2. The ctypes bindings and the module that selects them must both survive the
+#    .py/.pyc sweeps. Release images ship .pyc only; dev images ship both.
+for mod in secp256k1 ctypes_secp256k1; do
+	[ -f "${UTIL_DIR}/${mod}.pyc" ] || [ -f "${UTIL_DIR}/${mod}.py" ] \
+		|| fail "embit/util/${mod} is missing -- embit cannot bind to libsecp256k1"
+done
+
+# 3. Both ARM prebuilts must ship. All eight board configs are 32-bit ARM
+#    (BR2_arm=y), so platform.machine() reports armv6l (pi0) or armv7l (the rest)
+#    and embit looks up prebuilt/libsecp256k1_linux_<machine>.so by that exact
+#    name. Neither file alone covers every board.
+for so in libsecp256k1_linux_armv6l.so libsecp256k1_linux_armv7l.so; do
+	[ -f "${UTIL_DIR}/prebuilt/${so}" ] \
+		|| fail "prebuilt/${so} is missing -- boards reporting that machine type would have no library to load"
+done
+
+# 4. Nothing else should be in prebuilt/. A foreign-platform binary here is dead
+#    weight in a signing image, and its presence means the post-build cleanup has
+#    drifted from the set of files embit actually installs.
+#    Same two-part shape as check 1: the scan must complete before an empty
+#    result can be read as "nothing extra".
+if ! EXTRA="$(find "${UTIL_DIR}/prebuilt" -type f \
+	! -name 'libsecp256k1_linux_armv6l.so' \
+	! -name 'libsecp256k1_linux_armv7l.so')"; then
+	fail "could not scan ${UTIL_DIR}/prebuilt -- see find's errors above"
+fi
+if [ -n "${EXTRA}" ]; then
+	fail "unexpected files in embit/util/prebuilt:
+${EXTRA}"
+fi
+
+echo "verify-secp256k1-binary: OK (pre-compiled libsecp256k1 only, no Python fallback)"

--- a/opt/pi0-dev/board/post-build.sh
+++ b/opt/pi0-dev/board/post-build.sh
@@ -61,6 +61,13 @@ rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp25
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_linux_x86_64.so
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_windows_amd64.dll
 
+# Remove embit's pure-Python secp256k1 fallback: we must run only on the pre-compiled
+# libsecp256k1 C code or not at all. We explicitly opt for hard failure over silent
+# fallback.
+# We must delete both the .py and the .pyc to fully remove the fallback.
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.py
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.pyc
+
 # Dev convenience: make `python3 -m venv DIR` produce a usable venv by default.
 # This image's Python is built --without-ensurepip and carries the app's native
 # deps (PIL/numpy/embit/...) only in the system site-packages, so the two useful
@@ -96,3 +103,7 @@ find "${TARGET_DIR}" -name '.DS_Store' -print0 | xargs -0 --no-run-if-empty rm -
 SOURCE_DATE_EPOCH=1 PYTHONHASHSEED=0 ${HOST_DIR}/bin/python3.12 \
   "${BUILD_DIR}/python3-3.12.10/Lib/compileall.py" \
   -f --invalidation-mode=checked-hash "${TARGET_DIR}/opt/src"
+
+# Fail the build if embit can't reach the pre-compiled libsecp256k1 or if we detect the
+# pure-python secp256k1 fallback is present.
+"$(dirname "$0")/../../external-packages/python-embit/verify-secp256k1-binary.sh" "${TARGET_DIR}"

--- a/opt/pi0/board/post-build.sh
+++ b/opt/pi0/board/post-build.sh
@@ -37,6 +37,13 @@ rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp25
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_linux_x86_64.so
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_windows_amd64.dll
 
+# Remove embit's pure-Python secp256k1 fallback: we must run only on the pre-compiled
+# libsecp256k1 C code or not at all. We explicitly opt for hard failure over silent
+# fallback.
+# We must delete both the .py and the .pyc to fully remove the fallback.
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.py
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.pyc
+
 # Clean up tests/docs in other python included libs
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/pyzbar/tests
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/qrcode/tests
@@ -189,3 +196,7 @@ find "${TARGET_DIR}" -name '.DS_Store' -print0 | xargs -0 --no-run-if-empty rm -
 SOURCE_DATE_EPOCH=1 PYTHONHASHSEED=0 ${HOST_DIR}/bin/python3.12 \
   "${BUILD_DIR}/python3-3.12.10/Lib/compileall.py" \
   -f --invalidation-mode=checked-hash "${TARGET_DIR}/opt/src"
+
+# Fail the build if embit can't reach the pre-compiled libsecp256k1 or if we detect the
+# pure-python secp256k1 fallback is present.
+"$(dirname "$0")/../../external-packages/python-embit/verify-secp256k1-binary.sh" "${TARGET_DIR}"

--- a/opt/pi02w-dev/board/post-build.sh
+++ b/opt/pi02w-dev/board/post-build.sh
@@ -61,6 +61,13 @@ rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp25
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_linux_x86_64.so
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_windows_amd64.dll
 
+# Remove embit's pure-Python secp256k1 fallback: we must run only on the pre-compiled
+# libsecp256k1 C code or not at all. We explicitly opt for hard failure over silent
+# fallback.
+# We must delete both the .py and the .pyc to fully remove the fallback.
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.py
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.pyc
+
 # Dev convenience: make `python3 -m venv DIR` produce a usable venv by default.
 # This image's Python is built --without-ensurepip and carries the app's native
 # deps (PIL/numpy/embit/...) only in the system site-packages, so the two useful
@@ -96,3 +103,7 @@ find "${TARGET_DIR}" -name '.DS_Store' -print0 | xargs -0 --no-run-if-empty rm -
 SOURCE_DATE_EPOCH=1 PYTHONHASHSEED=0 ${HOST_DIR}/bin/python3.12 \
   "${BUILD_DIR}/python3-3.12.10/Lib/compileall.py" \
   -f --invalidation-mode=checked-hash "${TARGET_DIR}/opt/src"
+
+# Fail the build if embit can't reach the pre-compiled libsecp256k1 or if we detect the
+# pure-python secp256k1 fallback is present.
+"$(dirname "$0")/../../external-packages/python-embit/verify-secp256k1-binary.sh" "${TARGET_DIR}"

--- a/opt/pi02w/board/post-build.sh
+++ b/opt/pi02w/board/post-build.sh
@@ -37,6 +37,13 @@ rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp25
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_linux_x86_64.so
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_windows_amd64.dll
 
+# Remove embit's pure-Python secp256k1 fallback: we must run only on the pre-compiled
+# libsecp256k1 C code or not at all. We explicitly opt for hard failure over silent
+# fallback.
+# We must delete both the .py and the .pyc to fully remove the fallback.
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.py
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.pyc
+
 # Clean up tests/docs in other python included libs
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/pyzbar/tests
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/qrcode/tests
@@ -189,3 +196,7 @@ find "${TARGET_DIR}" -name '.DS_Store' -print0 | xargs -0 --no-run-if-empty rm -
 SOURCE_DATE_EPOCH=1 PYTHONHASHSEED=0 ${HOST_DIR}/bin/python3.12 \
   "${BUILD_DIR}/python3-3.12.10/Lib/compileall.py" \
   -f --invalidation-mode=checked-hash "${TARGET_DIR}/opt/src"
+
+# Fail the build if embit can't reach the pre-compiled libsecp256k1 or if we detect the
+# pure-python secp256k1 fallback is present.
+"$(dirname "$0")/../../external-packages/python-embit/verify-secp256k1-binary.sh" "${TARGET_DIR}"

--- a/opt/pi2-dev/board/post-build.sh
+++ b/opt/pi2-dev/board/post-build.sh
@@ -61,6 +61,13 @@ rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp25
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_linux_x86_64.so
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_windows_amd64.dll
 
+# Remove embit's pure-Python secp256k1 fallback: we must run only on the pre-compiled
+# libsecp256k1 C code or not at all. We explicitly opt for hard failure over silent
+# fallback.
+# We must delete both the .py and the .pyc to fully remove the fallback.
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.py
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.pyc
+
 # Dev convenience: make `python3 -m venv DIR` produce a usable venv by default.
 # This image's Python is built --without-ensurepip and carries the app's native
 # deps (PIL/numpy/embit/...) only in the system site-packages, so the two useful
@@ -96,3 +103,7 @@ find "${TARGET_DIR}" -name '.DS_Store' -print0 | xargs -0 --no-run-if-empty rm -
 SOURCE_DATE_EPOCH=1 PYTHONHASHSEED=0 ${HOST_DIR}/bin/python3.12 \
   "${BUILD_DIR}/python3-3.12.10/Lib/compileall.py" \
   -f --invalidation-mode=checked-hash "${TARGET_DIR}/opt/src"
+
+# Fail the build if embit can't reach the pre-compiled libsecp256k1 or if we detect the
+# pure-python secp256k1 fallback is present.
+"$(dirname "$0")/../../external-packages/python-embit/verify-secp256k1-binary.sh" "${TARGET_DIR}"

--- a/opt/pi2/board/post-build.sh
+++ b/opt/pi2/board/post-build.sh
@@ -37,6 +37,13 @@ rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp25
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_linux_x86_64.so
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_windows_amd64.dll
 
+# Remove embit's pure-Python secp256k1 fallback: we must run only on the pre-compiled
+# libsecp256k1 C code or not at all. We explicitly opt for hard failure over silent
+# fallback.
+# We must delete both the .py and the .pyc to fully remove the fallback.
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.py
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.pyc
+
 # Clean up tests/docs in other python included libs
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/pyzbar/tests
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/qrcode/tests
@@ -189,3 +196,7 @@ find "${TARGET_DIR}" -name '.DS_Store' -print0 | xargs -0 --no-run-if-empty rm -
 SOURCE_DATE_EPOCH=1 PYTHONHASHSEED=0 ${HOST_DIR}/bin/python3.12 \
   "${BUILD_DIR}/python3-3.12.10/Lib/compileall.py" \
   -f --invalidation-mode=checked-hash "${TARGET_DIR}/opt/src"
+
+# Fail the build if embit can't reach the pre-compiled libsecp256k1 or if we detect the
+# pure-python secp256k1 fallback is present.
+"$(dirname "$0")/../../external-packages/python-embit/verify-secp256k1-binary.sh" "${TARGET_DIR}"

--- a/opt/pi4-dev/board/post-build.sh
+++ b/opt/pi4-dev/board/post-build.sh
@@ -61,6 +61,13 @@ rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp25
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_linux_x86_64.so
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_windows_amd64.dll
 
+# Remove embit's pure-Python secp256k1 fallback: we must run only on the pre-compiled
+# libsecp256k1 C code or not at all. We explicitly opt for hard failure over silent
+# fallback.
+# We must delete both the .py and the .pyc to fully remove the fallback.
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.py
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.pyc
+
 # Dev convenience: make `python3 -m venv DIR` produce a usable venv by default.
 # This image's Python is built --without-ensurepip and carries the app's native
 # deps (PIL/numpy/embit/...) only in the system site-packages, so the two useful
@@ -96,3 +103,7 @@ find "${TARGET_DIR}" -name '.DS_Store' -print0 | xargs -0 --no-run-if-empty rm -
 SOURCE_DATE_EPOCH=1 PYTHONHASHSEED=0 ${HOST_DIR}/bin/python3.12 \
   "${BUILD_DIR}/python3-3.12.10/Lib/compileall.py" \
   -f --invalidation-mode=checked-hash "${TARGET_DIR}/opt/src"
+
+# Fail the build if embit can't reach the pre-compiled libsecp256k1 or if we detect the
+# pure-python secp256k1 fallback is present.
+"$(dirname "$0")/../../external-packages/python-embit/verify-secp256k1-binary.sh" "${TARGET_DIR}"

--- a/opt/pi4/board/post-build.sh
+++ b/opt/pi4/board/post-build.sh
@@ -37,6 +37,13 @@ rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp25
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_linux_x86_64.so
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/prebuilt/libsecp256k1_windows_amd64.dll
 
+# Remove embit's pure-Python secp256k1 fallback: we must run only on the pre-compiled
+# libsecp256k1 C code or not at all. We explicitly opt for hard failure over silent
+# fallback.
+# We must delete both the .py and the .pyc to fully remove the fallback.
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.py
+rm -f ${TARGET_DIR}/usr/lib/python3/site-packages/embit/util/py_secp256k1.pyc
+
 # Clean up tests/docs in other python included libs
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/pyzbar/tests
 rm -rf ${TARGET_DIR}/usr/lib/python3/site-packages/qrcode/tests
@@ -189,3 +196,7 @@ find "${TARGET_DIR}" -name '.DS_Store' -print0 | xargs -0 --no-run-if-empty rm -
 SOURCE_DATE_EPOCH=1 PYTHONHASHSEED=0 ${HOST_DIR}/bin/python3.12 \
   "${BUILD_DIR}/python3-3.12.10/Lib/compileall.py" \
   -f --invalidation-mode=checked-hash "${TARGET_DIR}/opt/src"
+
+# Fail the build if embit can't reach the pre-compiled libsecp256k1 or if we detect the
+# pure-python secp256k1 fallback is present.
+"$(dirname "$0")/../../external-packages/python-embit/verify-secp256k1-binary.sh" "${TARGET_DIR}"


### PR DESCRIPTION
Depends on #117 

Description below written by Claude:

---

Deleting py_secp256k1 from post-build.sh is not self-verifying. A future
embit bump, a changed pyc mode, or a reordered post-build step could put
the fallback back, and nothing would say so until a device silently signed
with Python.

Add opt/external-packages/python-embit/verify-secp256k1-binary.sh, called
as the last step of every board's post-build.sh. It fails the build if:

  1. any py_secp256k1.* survives anywhere in the target tree
  2. secp256k1 or ctypes_secp256k1 is missing (as .py or .pyc)
  3. either ARM prebuilt (armv6l for pi0, armv7l for the rest) is absent
  4. prebuilt/ holds anything beyond those two libraries

Checks 1 and 4 treat an incomplete scan as a failure in its own right: an
empty result from a find that died is indistinguishable from one that
found nothing, so absence has to be proven, not assumed.

## Build verification

Built `--pi0` from this branch with the standard Docker build. The build succeeded, and
the new check ran as part of it:

```
>>>   Executing post-build script ../pi0/board/post-build.sh
verify-secp256k1-binary: OK (pre-compiled libsecp256k1 only, no Python fallback)
```

### The check fails the build when it should

Each scenario was reproduced against the real build tree, not a mock-up. The regression
case restores a genuine `py_secp256k1.pyc`, recompiled from buildroot's own embit source
with buildroot's own host Python.

| scenario | result |
| --- | --- |
| unmodified build | passes |
| both `rm` lines deleted from `post-build.sh` | **exit 1**, build aborts |
| `libsecp256k1_linux_armv6l.so` missing | **exit 1** |
| stray `libsecp256k1_windows_amd64.dll` in `prebuilt/` | **exit 1** |

The check is the last line of `post-build.sh`, which runs under `set -e`, so a non-zero
exit fails the buildroot step rather than merely printing a warning.
