### PR TITLE
[Fix] Restore reproducible builds

### DIFF
--- a/opt/build.sh
+++ b/opt/build.sh
@@ -116,6 +116,7 @@ write_version_json() {
   # version.py silently discards the error, yielding a version.json that bricks boot.
   git config --global --add safe.directory "$(cd "${app_dir}" && pwd)"
 
+  # PYTHONPATH=src is enough; write_versionfile.py's imports are stdlib-only.
   export SEEDSIGNER_OS_BUILDER=1
   # -B (PYTHONDONTWRITEBYTECODE) is required for reproducible builds. Without it CPython
   # caches that import chain as timestamp-invalidated __pycache__/*.pyc 

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -116,9 +116,10 @@ write_version_json() {
   # version.py silently discards the error, yielding a version.json that bricks boot.
   git config --global --add safe.directory "$(cd "${app_dir}" && pwd)"
 
-  # PYTHONPATH=src is enough; write_versionfile.py's imports are stdlib-only.
   export SEEDSIGNER_OS_BUILDER=1
-  (cd "${app_dir}" && PYTHONPATH=src python3 tools/write_versionfile.py) || exit
+  # -B (PYTHONDONTWRITEBYTECODE) is required for reproducible builds. Without it CPython
+  # caches that import chain as timestamp-invalidated __pycache__/*.pyc 
+  (cd "${app_dir}" && PYTHONPATH=src python3 -B tools/write_versionfile.py) || exit
 }
 
 download_app_repo() {
@@ -154,7 +155,10 @@ delete_unnecessary_files() {
   rm -rf ${rootfs_overlay}/opt/enclosures
   rm -rf ${rootfs_overlay}/opt/l10n
   rm -rf ${rootfs_overlay}/opt/seedsigner-screenshots
+  rm -rf ${rootfs_overlay}/opt/src/seedsigner.egg-info
   rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/.git*
+  rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/.tx
+  rm -rf ${rootfs_overlay}/opt/src/seedsigner/resources/seedsigner-translations/tools
   rm -rf ${rootfs_overlay}/opt/tests
   rm -rf ${rootfs_overlay}/opt/tools
   # files
@@ -166,6 +170,7 @@ delete_unnecessary_files() {
   rm -rf ${rootfs_overlay}/opt/README.md
   rm -rf ${rootfs_overlay}/opt/requirements-raspi.txt
   rm -rf ${rootfs_overlay}/opt/requirements.txt
+  rm -rf ${rootfs_overlay}/opt/SECURITY.md
   rm -rf ${rootfs_overlay}/opt/seedsigner_pubkey.gpg
   rm -rf ${rootfs_overlay}/opt/setup.*
 


### PR DESCRIPTION
## Restore reproducible builds after #102

This restores reproducible builds, which broke when #102 merged. `__pycache__` was accidentally left in the image.

#102 added `python3 tools/write_versionfile.py`, run from inside `${rootfs_overlay}/opt`. It imports `seedsigner.helpers.version`, so CPython caches that import chain as timestamp-invalidated `__pycache__/*.pyc` in the overlay. Eight files, each storing the source mtime, which is the clone time, which is build time.

`board/post-build.sh` doesn't clear them. The build container runs Python 3.11 and the target runs 3.12, so `compileall` writes `cpython-312` files alongside the stale `cpython-311` ones instead of replacing them. Both sets ship.

Two builds of the same commit on the same host differed in 26 bytes: three surviving copies of a `.pyc` timestamp, plus the kernel `.note.gnu.build-id` that changed as a result.

## Fix

Run the script with `-B` (`PYTHONDONTWRITEBYTECODE`). Testing confirmed two clean builds hash identically.

## Also removed

One file and three directories that ship in `/opt` but nothing reads:

- `src/seedsigner.egg-info/`, a byproduct of `pip install -e .`
- `src/seedsigner/resources/seedsigner-translations/tools/`, build-time only
- `src/seedsigner/resources/seedsigner-translations/.tx/`, Transifex config
- `SECURITY.md`