### PR TITLE
[security] Pin and hash-lock the translation venv's pip installs

### DIFF
--- a/opt/build.sh
+++ b/opt/build.sh
@@ -47,10 +47,12 @@ compile_translations_and_fonts() {
 
   ss_translations_repo="./src/seedsigner/resources/seedsigner-translations"
 
-  # install depedencies for babel and fonttools(pyftsubset)
-  pip install babel || exit
-  pip install fonttools || exit
-  pip install -e . || exit
+  # install pinned, hash-locked dependencies: babel + setuptools come from the
+  # app repo's own l10n requirements; fonttools (pyftsubset) is a build-only
+  # addition pinned in this repo (see requirements-l10n-build.txt).
+  # --require-hashes fails the build if either file regresses to unhashed pins.
+  pip install --require-hashes -r l10n/requirements-l10n.txt || exit
+  pip install --require-hashes -r "${cur_dir}/requirements-l10n-build.txt" || exit
 
   # remove any existing binary mo files if they exist
   rm -rf ${ss_translations_repo}/l10n/**/**/*.mo

--- a/opt/requirements-l10n-build.txt
+++ b/opt/requirements-l10n-build.txt
@@ -1,0 +1,63 @@
+# Build-time dependencies that SeedSigner OS itself adds on top of the app
+# repo's l10n/requirements-l10n.txt (installed alongside this file by
+# compile_translations_and_fonts() in build.sh). Everything here goes into a
+# throwaway virtualenv during the image build and never ships in the image.
+#
+# Currently just fonttools, for pyftsubset: strips the Noto fonts down to only
+# the glyphs the translations actually use (an image-size optimization; app
+# devs never need it, which is why it does not belong in the app repo's file).
+#
+# Pinned and hash-locked (installed with pip --require-hashes) so a build can
+# only ever install the exact artifacts audited here. Hashes cover every file
+# of the release (all platform wheels + sdist) so builds work on any host.
+fonttools==4.57.0 \
+    --hash=sha256:babe8d1eb059a53e560e7bf29f8e8f4accc8b6cfb9b5fd10e485bde77e71ef41 \
+    --hash=sha256:81aa97669cd726349eb7bd43ca540cf418b279ee3caba5e2e295fb4e8f841c02 \
+    --hash=sha256:f0e9618630edd1910ad4f07f60d77c184b2f572c8ee43305ea3265675cbbfe7e \
+    --hash=sha256:34687a5d21f1d688d7d8d416cb4c5b9c87fca8a1797ec0d74b9fdebfa55c09ab \
+    --hash=sha256:69ab81b66ebaa8d430ba56c7a5f9abe0183afefd3a2d6e483060343398b13fb1 \
+    --hash=sha256:d639397de852f2ccfb3134b152c741406752640a266d9c1365b0f23d7b88077f \
+    --hash=sha256:cc066cb98b912f525ae901a24cd381a656f024f76203bc85f78fcc9e66ae5aec \
+    --hash=sha256:7a64edd3ff6a7f711a15bd70b4458611fb240176ec11ad8845ccbab4fe6745db \
+    --hash=sha256:3871349303bdec958360eedb619169a779956503ffb4543bb3e6211e09b647c4 \
+    --hash=sha256:c59375e85126b15a90fcba3443eaac58f3073ba091f02410eaa286da9ad80ed8 \
+    --hash=sha256:967b65232e104f4b0f6370a62eb33089e00024f2ce143aecbf9755649421c683 \
+    --hash=sha256:39acf68abdfc74e19de7485f8f7396fa4d2418efea239b7061d6ed6a2510c746 \
+    --hash=sha256:9d077f909f2343daf4495ba22bb0e23b62886e8ec7c109ee8234bdbd678cf344 \
+    --hash=sha256:46370ac47a1e91895d40e9ad48effbe8e9d9db1a4b80888095bc00e7beaa042f \
+    --hash=sha256:ca2aed95855506b7ae94e8f1f6217b7673c929e4f4f1217bcaa236253055cb36 \
+    --hash=sha256:17168a4670bbe3775f3f3f72d23ee786bd965395381dfbb70111e25e81505b9d \
+    --hash=sha256:889e45e976c74abc7256d3064aa7c1295aa283c6bb19810b9f8b604dfe5c7f31 \
+    --hash=sha256:0425c2e052a5f1516c94e5855dbda706ae5a768631e9fcc34e57d074d1b65b92 \
+    --hash=sha256:44c26a311be2ac130f40a96769264809d3b0cb297518669db437d1cc82974888 \
+    --hash=sha256:84c41ba992df5b8d680b89fd84c6a1f2aca2b9f1ae8a67400c8930cd4ea115f6 \
+    --hash=sha256:ea1e9e43ca56b0c12440a7c689b1350066595bebcaa83baad05b8b2675129d98 \
+    --hash=sha256:84fd56c78d431606332a0627c16e2a63d243d0d8b05521257d77c6529abe14d8 \
+    --hash=sha256:f4376819c1c778d59e0a31db5dc6ede854e9edf28bbfa5b756604727f7f800ac \
+    --hash=sha256:57e30241524879ea10cdf79c737037221f77cc126a8cdc8ff2c94d4a522504b9 \
+    --hash=sha256:408ce299696012d503b714778d89aa476f032414ae57e57b42e4b92363e0b8ef \
+    --hash=sha256:bbceffc80aa02d9e8b99f2a7491ed8c4a783b2fc4020119dc405ca14fb5c758c \
+    --hash=sha256:f022601f3ee9e1f6658ed6d184ce27fa5216cee5b82d279e0f0bde5deebece72 \
+    --hash=sha256:4dea5893b58d4637ffa925536462ba626f8a1b9ffbe2f5c272cdf2c6ebadb817 \
+    --hash=sha256:dff02c5c8423a657c550b48231d0a48d7e2b2e131088e55983cfe74ccc2c7cc9 \
+    --hash=sha256:767604f244dc17c68d3e2dbf98e038d11a18abc078f2d0f84b6c24571d9c0b13 \
+    --hash=sha256:8e2e12d0d862f43d51e5afb8b9751c77e6bec7d2dc00aad80641364e9df5b199 \
+    --hash=sha256:f1d6bc9c23356908db712d282acb3eebd4ae5ec6d8b696aa40342b1d84f8e9e3 \
+    --hash=sha256:9d57b4e23ebbe985125d3f0cabbf286efa191ab60bbadb9326091050d88e8213 \
+    --hash=sha256:579ba873d7f2a96f78b2e11028f7472146ae181cae0e4d814a37a09e93d5c5cc \
+    --hash=sha256:6e3e1ec10c29bae0ea826b61f265ec5c858c5ba2ce2e69a71a62f285cf8e4595 \
+    --hash=sha256:a1968f2a2003c97c4ce6308dc2498d5fd4364ad309900930aa5a503c9851aec8 \
+    --hash=sha256:aff40f8ac6763d05c2c8f6d240c6dac4bb92640a86d9b0c3f3fff4404f34095c \
+    --hash=sha256:d07f1b64008e39fceae7aa99e38df8385d7d24a474a8c9872645c4397b674481 \
+    --hash=sha256:51d8482e96b28fb28aa8e50b5706f3cee06de85cbe2dce80dbd1917ae22ec5a6 \
+    --hash=sha256:03290e818782e7edb159474144fca11e36a8ed6663d1fcbd5268eb550594fd8e \
+    --hash=sha256:7339e6a3283e4b0ade99cade51e97cde3d54cd6d1c3744459e886b66d630c8b3 \
+    --hash=sha256:05efceb2cb5f6ec92a4180fcb7a64aa8d3385fd49cfbbe459350229d1974f0b1 \
+    --hash=sha256:a97bb05eb24637714a04dee85bdf0ad1941df64fe3b802ee4ac1c284a5f97b7c \
+    --hash=sha256:541cb48191a19ceb1a2a4b90c1fcebd22a1ff7491010d3cf840dd3a68aebd654 \
+    --hash=sha256:cdef9a056c222d0479a1fdb721430f9efd68268014c54e8166133d2643cb05d9 \
+    --hash=sha256:3cf97236b192a50a4bf200dc5ba405aa78d4f537a2c6e4c624bb60466d5b03bd \
+    --hash=sha256:e952c684274a7714b3160f57ec1d78309f955c6335c04433f07d36c5eb27b1f9 \
+    --hash=sha256:a2a722c0e4bfd9966a11ff55c895c817158fcce1b2b6700205a376403b546ad9 \
+    --hash=sha256:3122c604a675513c68bd24c6a8f9091f1c2376d18e8f5fe5a101746c81b3e98f \
+    --hash=sha256:727ece10e065be2f9dd239d15dd5d60a66e17eac11aea47d447f9f03fdbc42de


### PR DESCRIPTION
Description by Claude, reviewed and edited by Keith.

---

## Motivation

There was a report that unpinned pip dependencies get installed during
the image build. Confirmed: `compile_translations_and_fonts()` in
`opt/build.sh` installed `babel` and `fonttools` with no version pins,
so every build downloaded whatever PyPI served that day. A third line,
`pip install -e .`, was worse than unpinned — it invisibly pulled the
latest setuptools and wheel via PEP 517 build isolation.

The venv never ships in the image, but it runs at build time with
network access and its **output does ship**: the compiled .mo
translation catalogs and the subset Noto fonts. For a signing-device
OS, that's a supply-chain surface worth closing. (The runtime
dependencies — Pillow, embit, etc. — were already fine: they enter the
image as buildroot packages, version-pinned and hash-verified at
download.)

## Changes

- **Both pip installs are now pinned and hash-locked**, run with
  `--require-hashes` so pip refuses any artifact whose sha256 doesn't
  match what was audited — and so the build fails closed if either
  requirements file ever regresses to unhashed pins.
- **babel + setuptools** come from the app repo's own
  `l10n/requirements-l10n.txt` (hash-locked in SeedSigner/seedsigner#1011),
  keeping a single source of truth with the app's translation workflow.
- **fonttools** (`pyftsubset`) lives in the new
  `opt/requirements-l10n-build.txt` in this repo: font subsetting is
  purely an image-size optimization that app devs never need, so it
  doesn't belong in the app repo's file. Pinned to 4.57.0 with hashes
  covering every file of the release (all wheels + sdist), so builds
  work on any host.
- **`pip install -e .` is removed.** It was vestigial: it existed for
  `write_versionfile.py`, which e80678e moved out of the venv and made
  stdlib-only. Nothing left in the function imports the app package,
  and removing it also removes the unpinned setuptools/wheel downloads.

## Testing

The full pipeline was verified in a fresh venv installed exclusively
through the hash-checked requirements (babel 2.16.0, fonttools 4.57.0,
setuptools 84.0.0): `compile_catalog` compiled all locale catalogs,
character extraction worked, and `pyftsubset` produced correct subset
fonts (e.g. NotoSansJP 5.7MB → 113KB).

## Merge dependency

**Depends on SeedSigner/seedsigner#1011.** Builds clone the app repo,
and `--require-hashes` on the l10n install fails until the hash-locked
`l10n/requirements-l10n.txt` from that PR lands on the app branch
being built (`dev` by default). Merge #1011 first; merged in the other
order, every image build breaks with pip's "hashes are required"
error.

## Additional info
Responsibly disclosed by @asafmod