### PR TITLE
build: remove AGENTS.md from build

### DIFF
--- a/opt/build.sh
+++ b/opt/build.sh
@@ -166,6 +166,8 @@ delete_unnecessary_files() {
   rm -rf ${rootfs_overlay}/opt/tools
   # files
   rm -rf ${rootfs_overlay}/opt/.git*
+  rm -rf ${rootfs_overlay}/opt/AGENTS.md
+  rm -rf ${rootfs_overlay}/opt/CLAUDE.md
   rm -rf ${rootfs_overlay}/opt/docker-compose.yml
   rm -rf ${rootfs_overlay}/opt/LICENSE.md
   rm -rf ${rootfs_overlay}/opt/MANIFEST.in


### PR DESCRIPTION
Related to https://github.com/SeedSigner/seedsigner/pull/986.

This PR ensures that the additional file from the above PR is removed during the build process.
